### PR TITLE
Add autoload cookies to commands and keybindings.

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -111,7 +111,7 @@ string if you want to disable timestamps."
      (define-key calendar-mode-map "[" 'org-journal-previous-entry)
      (define-key calendar-mode-map (kbd "i j") 'org-journal-new-date-entry)))
 ;;;###autoload
-(global-set-key "\C-cj" 'org-journal-new-entry)
+(global-set-key (kbd "C-c j") 'org-journal-new-entry)
 
 ;; Creates a new entry
 ;;;###autoload


### PR DESCRIPTION
With the cookies on the commands and the keybindings as entry points
org-journal will be usable via package.el without explicitly loading it.
