### PR TITLE
org-journal-read-entry Cannot Find Journal Entry

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -242,19 +242,22 @@ If the date is not today, it won't be given a time."
       (calendar-mark-visible-date journal-entry))))
 
 ;;;###autoload
-(defun org-journal-read-entry ()
+(defun org-journal-read-entry (arg &optional event)
   "Open journal entry for selected date for viewing"
-  (interactive)
-  (setq org-journal-file
-        (int-to-string (+ (* 10000 (nth 2 (calendar-cursor-to-date)))
-                          (* 100 (nth 0 (calendar-cursor-to-date)))
-                          (nth 1 (calendar-cursor-to-date)))))
-  (if (file-exists-p (concat org-journal-dir org-journal-file))
-      (progn
-        (view-file-other-window (concat org-journal-dir org-journal-file))
-        (setq-local org-hide-emphasis-markers t)
-        (org-show-subtree))
-    (message "No journal entry for this date.")))
+  (interactive
+   (list current-prefix-arg last-nonmenu-event))
+
+  (let* ((time (org-journal-calendar-date->time
+                (calendar-cursor-to-date t event)))
+         (org-journal-file (concat org-journal-dir
+                                   (format-time-string org-journal-file-format time))))
+
+    (if (file-exists-p org-journal-file)
+        (progn
+          (view-file-other-window org-journal-file)
+          (setq-local org-hide-emphasis-markers t)
+          (org-show-subtree))
+      (message "No journal entry for this date."))))
 
 ;;;###autoload
 (defun org-journal-next-entry ()


### PR DESCRIPTION
#### The Setup

Following the advice of the README, I am customizing my org-journal-file-format and org-journal-file-pattern variables.  This seems to be working correctly and the days with journal entries are highlighted in calendar mode.  The settings for each follow:

```
(setq-default org-journal-file-format "%Y%m%d.org-j")
(setq-default org-journal-file-pattern "[0-9]\\{8\\}.org-j$")
```
#### The Problem

In calendar view, if I hit 'j' to view the journal entry, I receive the message "No journal entry for this date".  Clearly, this is because org-journal-read-entry has hard-coded logic to look for a file in YYYYmmdd format.

I would like to try my hand at working on a patch for this issue, but I was curious how you think I should go about it.  Should we provide some custom function the user can define to  lookup the file?  Can you think of a better solution?
