### PR TITLE
Fix load with defaults

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -48,10 +48,11 @@
 (defun org-journal-update-auto-mode-alist ()
   "Update auto-mode-alist to open journal files in
   org-journal-mode"
-  (let ((name (concat (file-truename org-journal-dir)
-                      org-journal-file-pattern)))
-    (add-to-list 'auto-mode-alist
-                 (cons name 'org-journal-mode))))
+  (if (and (boundp 'org-journal-dir) (boundp 'org-journal-file-pattern))
+      (let ((name (concat (file-truename org-journal-dir)
+			  org-journal-file-pattern)))
+	(add-to-list 'auto-mode-alist
+		     (cons name 'org-journal-mode)))))
 
 ; Customizable variables
 (defgroup org-journal nil


### PR DESCRIPTION
Now, org-journal-file-pattern and org-journal-dir must be set before
load, otherwise void variable error will be reported.  This patch
makes it possible to load org-journal with default settings, that is,
do not need to setup org-journal-file-pattern and org-journal-dir.
