### PR TITLE
Set org-journal-mode on new entry

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -156,7 +156,8 @@ string if you want to disable timestamps."
     (insert "\n" org-journal-time-prefix
             (format-time-string org-journal-time-format))
     (hide-sublevels 2)
-    (set-buffer-modified-p unsaved)))
+    (set-buffer-modified-p unsaved))
+  (org-journal-mode))
 
 (defun org-journal-calendar-date->time (calendar-date)
   "Convert a date as returned from the calendar to a time"


### PR DESCRIPTION
Sets org-journal-mode for file opened by org-journal-new-entry
(i.e. C-c j)

While this can be done via auto-mode-alist, I feel that since org-journal-new-entry _clearly_ creates a new journal entry meant to be managed via org-journal-mode, it should just set the mode for it by default. 
