### PR TITLE
Enable org-journal-mode before using outline.el defuns

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -177,9 +177,9 @@ string if you want to disable timestamps."
     (unless (eq (current-column) 0) (insert "\n"))
     (insert "\n" org-journal-time-prefix
             (format-time-string org-journal-time-format))
+    (org-journal-mode)
     (hide-sublevels 2)
-    (set-buffer-modified-p unsaved))
-  (org-journal-mode))
+    (set-buffer-modified-p unsaved)))
 
 (defun org-journal-calendar-date->time (calendar-date)
   "Convert a date as returned from the calendar to a time"


### PR DESCRIPTION
When creating a new org-journal-entry, if org-mode or outline mode
haven't already been enabled, then you will receive the error:

`Symbol's function definition is void hide-sublevels:`

In order to fix this, we enable org-journal-mode prior to calling
`hide-sublevels`
