### PR TITLE
Calendar improvement: C-j now just opens an entry in another window without selecting it

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -146,6 +146,7 @@ string if you want to disable timestamps."
 (eval-after-load "calendar"
   '(progn
      (define-key calendar-mode-map "j" 'org-journal-read-entry)
+     (define-key calendar-mode-map (kbd "C-j") 'org-journal-display-entry)
      (define-key calendar-mode-map "]" 'org-journal-next-entry)
      (define-key calendar-mode-map "[" 'org-journal-previous-entry)
      (define-key calendar-mode-map (kbd "i j") 'org-journal-new-date-entry)))
@@ -301,7 +302,7 @@ If the date is not today, it won't be given a time."
   "Mark days in the calendar for which a diary entry is present"
   (dolist (journal-entry org-journal-date-list)
     (if (calendar-date-is-visible-p journal-entry)
-      (calendar-mark-visible-date journal-entry))))
+        (calendar-mark-visible-date journal-entry))))
 
 ;;;###autoload
 (defun org-journal-read-entry (arg &optional event)
@@ -310,21 +311,42 @@ If the date is not today, it won't be given a time."
    (list current-prefix-arg last-nonmenu-event))
 
   (let* ((time (org-journal-calendar-date->time
-                (calendar-cursor-to-date t event)))
-         (org-journal-file (concat org-journal-dir
-                                   (format-time-string org-journal-file-format time))))
+                (calendar-cursor-to-date t event))))
+    (org-journal-read-or-display-entry time nil)))
+
+;;;###autoload
+(defun org-journal-display-entry (arg &optional event)
+  "Display journal entry for selected date in another
+  window (without switсhing to it)"
+  (interactive
+   (list current-prefix-arg last-nonmenu-event))
+  (let* ((time (org-journal-calendar-date->time
+                (calendar-cursor-to-date t event))))
+    (org-journal-read-or-display-entry time t)))
+
+;;;###autoload
+(defun org-journal-read-or-display-entry (time &optional noselect)
+  "Read an entry for the TIME and either select the new
+  window (NOSELECT is nil) or avoid switching (NOSELECT is
+  non-nil"
+  (let ((org-journal-file (concat org-journal-dir
+                                  (format-time-string org-journal-file-format time))))
     (if (file-exists-p org-journal-file)
         (progn
           ;; open file in view-mode if not opened already
-          (let ((had-a-buf (get-file-buffer org-journal-file)))
-            ;; use find-file... instead of view-file... since
-            ;; view-file does not respect auto-mode-alist
-            (find-file-other-window org-journal-file)
-            (when (not had-a-buf)
-              (view-mode)
-              (setq view-exit-action 'kill-buffer)))
-          (setq-local org-hide-emphasis-markers t)
-          (org-show-subtree))
+          (let ((had-a-buf (get-file-buffer org-journal-file))
+                ;; use find-file... instead of view-file... since
+                ;; view-file does not respect auto-mode-alist
+                (buf (find-file-noselect org-journal-file)))
+            (with-current-buffer buf
+              (when (not had-a-buf)
+                (view-mode)
+                (setq view-exit-action 'kill-buffer))
+              (setq-local org-hide-emphasis-markers t)
+              (org-show-subtree))
+            (if (not noselect)
+                (find-file-other-window org-journal-file)
+              (display-buffer buf t))))
       (message "No journal entry for this date."))))
 
 ;;;###autoload


### PR DESCRIPTION
One more minor improvement. :-)

Consider the following case. Sometimes I just want to browse my journal entries in the calendar without any edits. Pressing "j" will inevitably open a new window, select it... To get back to the calendar I have to press an extra button. In dired you can check out files without selecting the buffer (o vs C-o vs C-M-o). So I added one more calendar-mode-map keybinding, which does exactly that and - hopefully - is easy to remember: C-j. 

I refactored out some code into a common function - org-journal-read-or-display-entry, which chooses between displaying and switching.
