### PR TITLE
#27 Basic journal search facility

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -404,11 +404,11 @@ If a prefix argument is given, search all dates."
   (interactive (list (read-string "Enter a string to search for: " nil 'org-journal-search-history)))
   (org-journal-search str 'week))
 (defun org-journal-search-calendar-month (str)
-  "Search for a string within a current calendar-mode week entries"
+  "Search for a string within a current calendar-mode month entries"
   (interactive (list (read-string "Enter a string to search for: " nil 'org-journal-search-history)))
   (org-journal-search str 'month))
 (defun org-journal-search-calendar-year (str)
-  "Search for a string within a current calendar-mode week entries"
+  "Search for a string within a current calendar-mode year entries"
   (interactive (list (read-string "Enter a string to search for: " nil 'org-journal-search-history)))
   (org-journal-search str 'year))
 (defun org-journal-search-forever (str)
@@ -434,8 +434,8 @@ calendar accordingly."
 
    ;; eternity start/end
    ((eq period-name 'forever)
-      (cons (list 1 1 1970)
-            (list 12 31 3000)))
+    (cons (list 1 1 1971)
+          (list 12 31 2030)))
 
    ;; extract a year start/end using the calendar curson
    ((and (eq period-name 'year) (eq major-mode 'calendar-mode))
@@ -552,7 +552,9 @@ calendar accordingly."
       (princ "\n")))
   (local-set-key (kbd "q") 'kill-this-buffer)
   (local-set-key (kbd "<tab>") 'forward-button)
-  (local-set-key (kbd "<backtab>") 'backward-button))
+  (local-set-key (kbd "<backtab>") 'backward-button)
+  (local-set-key (kbd "n") 'forward-button)
+  (local-set-key (kbd "p") 'backward-button))
 
 (defun org-journal-search-follow-link-action (button)
   "Follow the link using info saved in button properties"

--- a/org-journal.el
+++ b/org-journal.el
@@ -333,7 +333,7 @@ If the date is not today, it won't be given a time."
 (defun org-journal-read-or-display-entry (time &optional noselect)
   "Read an entry for the TIME and either select the new
   window (NOSELECT is nil) or avoid switching (NOSELECT is
-  non-nil"
+  non-nil."
   (let ((org-journal-file (concat org-journal-dir
                                   (format-time-string org-journal-file-format time))))
     (if (file-exists-p org-journal-file)
@@ -394,6 +394,19 @@ See `org-read-date` for information on ways to specify dates."
     (org-journal-search-by-string str start end)))
 (defvar org-journal-search-history nil)
 
+(defun org-journal-search-calendar-week (str)
+  "Search for a string within a current calendar-mode week entries"
+  (interactive (list (read-string "Enter a string to search for: " nil 'org-journal-search-history)))
+  (org-journal-search str 'week))
+(defun org-journal-search-calendar-month (str)
+  "Search for a string within a current calendar-mode week entries"
+  (interactive (list (read-string "Enter a string to search for: " nil 'org-journal-search-history)))
+  (org-journal-search str 'month))
+(defun org-journal-search-calendar-year (str)
+  "Search for a string within a current calendar-mode week entries"
+  (interactive (list (read-string "Enter a string to search for: " nil 'org-journal-search-history)))
+  (org-journal-search str 'year))
+
 (defun org-journal-read-period (period-name)
   "If the PERIOD-NAME is nil, then ask the user for period
 start/end; if PERIOD-NAME is a symbol equal to 'week/'month/'year
@@ -401,9 +414,11 @@ then use current week/month/year from the calendar accordingly."
   (cond
    ;; no period-name? ask the user for input
    ((not period-name)
-    (let ((org-read-date-prefer-future nil)
-          (start (org-read-date nil t nil "Enter a period start"))
-          (end (org-read-date nil t nil "Enter a period end")))
+    (let* ((org-read-date-prefer-future nil)
+           (absolute-start (time-to-days (org-read-date nil t nil "Enter a period start")))
+           (absolute-end (time-to-days (org-read-date nil t nil "Enter a period end")))
+           (start (calendar-gregorian-from-absolute absolute-start))
+           (end (calendar-gregorian-from-absolute absolute-end)))
       (cons start end)))
 
    ;; extract a year start/end using the calendar curson
@@ -521,6 +536,7 @@ then use current week/month/year from the calendar accordingly."
     (org-journal-read-or-display-entry
      (org-journal-calendar-date->time
       (org-journal-file-name->calendar-date (file-name-base fname))))
+    (show-all) ; TODO: could not find out a proper way to go to a hidden line
     (goto-char (point-min))
     (forward-line (1- lnum))))
 

--- a/org-journal.el
+++ b/org-journal.el
@@ -460,7 +460,7 @@ See `org-read-date` for information on ways to specify dates."
                    (file-name-base fname))))
            (label (format-time-string org-journal-date-format time)))
       (insert-text-button label
-                          'action 'search-journal-follow-link-action
+                          'action 'org-journal-search-follow-link-action
                           'org-journal-link (cons fname lnum))
       (princ "\t")
       (princ fullstr)
@@ -471,7 +471,9 @@ See `org-read-date` for information on ways to specify dates."
   (let* ((target (button-get button 'org-journal-link))
          (fname (car target))
          (lnum (cdr target)))
-    (find-file-other-window  fname)
+    (org-journal-read-or-display-entry
+     (org-journal-calendar-date->time
+      (org-journal-file-name->calendar-date (file-name-base fname))))
     (goto-char (point-min))
     (forward-line (1- lnum))))
 

--- a/org-journal.el
+++ b/org-journal.el
@@ -466,8 +466,7 @@ then use current week/month/year from the calendar accordingly."
          (results (org-journal-search-do-search str files)))
     (with-current-buffer-window
      "*Org-journal search*" nil nil
-     (princ (concat "Search results for \"" str "\": \n\n"))
-     (org-journal-search-print-results results))))
+     (org-journal-search-print-results str results period-start period-end))))
 
 (defun org-journal-search-build-file-list (&optional period-start period-end)
   "Build a list of journal files within a given time interval"
@@ -511,8 +510,13 @@ then use current week/month/year from the calendar accordingly."
             (push res results)))))
     results))
 
-(defun org-journal-search-print-results (results)
+(defun org-journal-search-print-results (str results period-start period-end)
   "Print search results using text buttons"
+  (let ((label-start (format-time-string org-journal-date-format period-start))
+        (label-end (format-time-string org-journal-date-format period-end)))
+    (princ (concat "Search results for \"" str "\" between "
+                   label-start " and " label-end
+                   ": \n\n")))
   (dolist (res results)
     (let* ((fname (nth 0 res))
            (lnum (nth 1 res))
@@ -520,7 +524,10 @@ then use current week/month/year from the calendar accordingly."
            (time (org-journal-calendar-date->time
                   (org-journal-file-name->calendar-date
                    (file-name-base fname))))
-           (label (format-time-string org-journal-date-format time)))
+           (label (format-time-string org-journal-date-format time))
+
+           (label-end (format-time-string org-journal-date-format period-start)))
+
       (insert-text-button label
                           'action 'org-journal-search-follow-link-action
                           'org-journal-link (cons fname lnum))


### PR DESCRIPTION
Here goes.

The main entry point is the `org-journal-search` function, which asks for a search string and two dates (start end). Dates are read using the `org-read-date` function, which allows a rather free-form date entry (like `-7d` or `-1m`) plus a calendar-based date selection.

The results are just a read-only buffer with clickable (mouse/keyboard) links. I am thinking about implementing a nicer mode for the result buffer, but for now this should do.

I also played with a tag-based search, which collects tags from all the files and builds an index... Don't know if it's worth it.

Please, give it a try and let me know.