### PR TITLE
Two minor improvements for org-mode

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -57,7 +57,7 @@
 (defun org-journal-update-auto-mode-alist ()
   "Update auto-mode-alist to open journal files in
   org-journal-mode"
-  (let ((name (concat (file-truename org-journal-dir)
+  (let ((name (concat (expand-file-name org-journal-dir)
                       (substring org-journal-file-pattern 1))))
     (add-to-list 'auto-mode-alist
                  (cons name 'org-journal-mode))))

--- a/org-journal.el
+++ b/org-journal.el
@@ -187,29 +187,32 @@ without adding an entry"
   (org-journal-dir-check-or-create)
   (let* ((entry-path (concat org-journal-dir
                              (format-time-string org-journal-file-format)))
-         (entry-path-exists-p (file-exists-p entry-path)))
-    ;; a prefix arg is given and there's no current journal entry? error, as
-    ;; there's no current entry to open
-    (when (and prefix
-               (not entry-path-exists-p))
-      (error "There's no current entry to open."))
-    (find-file entry-path))
-  (goto-char (point-max))
-  (let ((unsaved (buffer-modified-p)))
-    ;; skip entry adding if a universal prefix is given
-    (unless prefix
-      (if (equal (point-max) 1)
-          (insert org-journal-date-prefix
-                  (format-time-string org-journal-date-format)))
-      (unless (eq (current-column) 0) (insert "\n"))
-      (insert "\n" org-journal-time-prefix
-              (format-time-string org-journal-time-format)))
-    (org-journal-mode)
-    (hide-sublevels 2)
-    ;; open the most recent entry
-    (when prefix
-      (show-entry))
-    (set-buffer-modified-p unsaved)))
+         (entry-path-exists-p (file-exists-p entry-path))
+         (should-add-entry-p (not prefix)))
+    (find-file entry-path)
+    (goto-char (point-max))
+    (let ((unsaved (buffer-modified-p)))
+
+      ;; empty file? Add a date timestamp
+      (when (equal (point-max) 1)
+        (insert org-journal-date-prefix
+                (format-time-string org-journal-date-format)))
+
+      ;; skip entry adding if a prefix is given
+      (when should-add-entry-p
+        (unless (eq (current-column) 0) (insert "\n"))
+        (insert "\n" org-journal-time-prefix
+                (format-time-string org-journal-time-format)))
+
+      ;; switch to the outline, hide subtrees
+      (org-journal-mode)
+      (hide-sublevels 2)
+
+      ;; open the recent entry when the prefix is given
+      (unless should-add-entry-p
+        (show-entry))
+
+      (set-buffer-modified-p unsaved))))
 
 (defun org-journal-calendar-date->time (calendar-date)
   "Convert a date as returned from the calendar to a time"

--- a/org-journal.el
+++ b/org-journal.el
@@ -185,8 +185,15 @@ Giving the command a prefix arg will just open a today's file,
 without adding an entry"
   (interactive "P")
   (org-journal-dir-check-or-create)
-  (find-file (concat org-journal-dir
-                     (format-time-string org-journal-file-format)))
+  (let* ((entry-path (concat org-journal-dir
+                             (format-time-string org-journal-file-format)))
+         (entry-path-exists-p (file-exists-p entry-path)))
+    ;; a prefix arg is given and there's no current journal entry? error, as
+    ;; there's no current entry to open
+    (when (and prefix
+               (not entry-path-exists-p))
+      (error "There's no current entry to open."))
+    (find-file entry-path))
   (goto-char (point-max))
   (let ((unsaved (buffer-modified-p)))
     ;; skip entry adding if a universal prefix is given
@@ -199,7 +206,7 @@ without adding an entry"
               (format-time-string org-journal-time-format)))
     (org-journal-mode)
     (hide-sublevels 2)
-    ;; open the last entry
+    ;; open the most recent entry
     (when prefix
       (show-entry))
     (set-buffer-modified-p unsaved)))


### PR DESCRIPTION
1. The first improvement is plain and simple: with a prefix arg `org-journal-new-entry` opens a current entry. If there's no entry - it opens an empty file, which is clearly wrong. The first commit fixes the problem by making the function throw an error in the situation.

2. The second improvement is a bit controversial. 

A have my journal files stored in a Dropbox directory (~/Dropbox/Documents/journal), which allows for sharing between my home and office machines. My ~/Documents directory is just a symlink to ~/Dropbox/Documents (on both office Windows and home Linux machines).

Now, if I set org-journal-dir to ~/Dropbox/Documents/journal, then (buffer-file-name) in any of the journal entry files does not match the auto-mode-alist regex (filename = "~/Documents/journal/...", regex = "~/Dropbox/Documents/.....").

If I set org-journal-dir to to ~/Documents/journal then org-journal-update-auto-mode-alist expands it to ~/Dropbox/Documents/journal anyway, because it uses `file-truename`, which expands the all the symlinks. So, I changed file-truename for `expand-file-name`, which works like charm.

And I could not come up with a situation where the change would hurt.