### PR TITLE
improve auto hiding of time entries

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -193,24 +193,28 @@ without adding an entry"
   (find-file (concat org-journal-dir
                      (format-time-string org-journal-file-format)))
   (goto-char (point-max))
-  (let ((unsaved (buffer-modified-p)))
-    ;; skip entry adding if a universal prefix is given
-    (unless prefix
-      (if (equal (point-max) 1)
-          (insert org-journal-date-prefix
-                  (format-time-string org-journal-date-format)))
+  (unless prefix
+    (let ((unsaved (buffer-modified-p))
+          (date-string (concat org-journal-date-prefix
+                               (format-time-string org-journal-date-format)))
+          (level (org-journal-figure-time-entry-level)))
+      (unless (buffer-contains-substring? date-string)
+        (insert date-string))
       (unless (eq (current-column) 0) (insert "\n"))
       (insert "\n" org-journal-time-prefix
-              (format-time-string org-journal-time-format)))
-    (org-journal-mode)
-    (when org-journal-do-hide-entries-on-new
-      (let ((level (org-journal-figure-time-entry-level)))
-        (when level
-          (hide-sublevels level)
-          ;; open the last entry
-          (when prefix
-            (show-entry)))))
-    (set-buffer-modified-p unsaved)))
+              (format-time-string org-journal-time-format))
+      (org-journal-mode)
+      (when (and org-journal-do-hide-entries-on-new
+                 level)
+        (hide-sublevels level)
+        (show-entry))
+      (set-buffer-modified-p unsaved))))
+
+(defun buffer-contains-substring? (string)
+  (save-excursion
+    (save-match-data
+      (goto-char (point-min))
+      (search-forward string nil t))))
 
 (defun org-journal-figure-time-entry-level ()
   "Return the level of time entry based on value of 'org-journal-time-prefix.

--- a/org-journal.el
+++ b/org-journal.el
@@ -129,6 +129,11 @@ string if you want to disable timestamps."
   "String that is put before every time entry in a journal file.
   By default, this is an org-mode sub-heading."
   :type 'string :group 'org-journal)
+(defcustom org-journal-do-hide-entries-on-new t
+  "If set to non nil value, then org-mode will try to hide
+   time entries when creating new one. It will hide them only
+   if 'org-journal-time-prefix is valid org heading prefix
+   with trailing space.")
 
 (require 'calendar)
 ;;;###autoload
@@ -198,11 +203,20 @@ without adding an entry"
       (insert "\n" org-journal-time-prefix
               (format-time-string org-journal-time-format)))
     (org-journal-mode)
-    (hide-sublevels 2)
-    ;; open the last entry
-    (when prefix
-      (show-entry))
+    (when org-journal-do-hide-entries-on-new
+      (let ((level (org-journal-figure-time-entry-level)))
+        (when level
+          (hide-sublevels level)
+          ;; open the last entry
+          (when prefix
+            (show-entry)))))
     (set-buffer-modified-p unsaved)))
+
+(defun org-journal-figure-time-entry-level ()
+  "Return the level of time entry based on value of 'org-journal-time-prefix.
+   Return nil, when it's impossible to figure out it's level."
+  (when (eq (string-match-p "\*+ " org-journal-time-prefix 0) 0)
+      (- (length org-journal-time-prefix) 1)))
 
 (defun org-journal-calendar-date->time (calendar-date)
   "Convert a date as returned from the calendar to a time"


### PR DESCRIPTION
* define 'org-journal-do-hide-entries-on-new variable that is used to
  decide either to hide time entries or not when creating new one using
  'org-journal-new-entry function
* don't hide second level when creating new entry, but instead try to
  figure out the level of time entries from 'org-journal-time-prefix
  variable

---

Some explanations. 

**Visibility**

I thought that it might be good idea to let user to setup org-journal in a way that respects visibility of file when creating new entry. Personally, I like seeing previous notes, because I usually run in full-screen mode. 

**Figure level**

When I was adding support of visibility respect I noticed that function that creates new entry actually hides second level no matter what is set to `org-journal-time-prefix`. So like if even users uses `"* "` as `org-journal-time-prefix` it will hide second level instead of first (I think that this is what was intended, right?). So I updated it by creating new function that tries to figure out level from `org-journal-time-prefix` value. When it fails to do so - it just return `nil`, so nothing hides. 

---

My elisp-fu is no very good, so probably it all might be implemented in better way. In that case - consider my pull request as open feature request :D Also I apologise if names I used for new variable and new functions are bad - feel free to changes them (as well as description to them). 

Cheers, Boris.

P. S. Thank you for you package - it helps a lot in daily routine! 