### PR TITLE
Add Spacemacs layer guide to README

### DIFF
--- a/README.org
+++ b/README.org
@@ -61,6 +61,11 @@ should be trivial:
 
 Then add =(require 'org-journal)= to your =.emacs=.
 
+*** Spacemacs Layer for org-journal
+
+To use =org-journal= on Spacemacs with Spacemacs-style key bindings, please check
+[[https://github.com/borgnix/spacemacs-journal][journal]] layer.
+
 ** Quickstart
 
 Doing =C-x org-journal-new-entry= (or =C-c C-j=) will immediately create a journal

--- a/README.org
+++ b/README.org
@@ -63,8 +63,12 @@ Then add =(require 'org-journal)= to your =.emacs=.
 
 *** Spacemacs Layer for org-journal
 
-To use =org-journal= on Spacemacs with Spacemacs-style key bindings, please check
-[[https://github.com/borgnix/spacemacs-journal][journal]] layer.
+To use =org-journal= on Spacemacs, you could :
+
+1. =git clone https://github.com/borgnix/spacemacs-journal.git ~/.emacs.d/private/journal=
+2. add it to your =~/.spacemacs=. You will need to add =journal= to the existing =dotspacemacs-configuration-layers= list in this file.
+
+The manual of the journal layer can be found at https://github.com/borgnix/spacemacs-journal
 
 ** Quickstart
 


### PR DESCRIPTION
Hi. I really enjoy the journaling experience with `org-journal`, so I made a Spacemacs layer to provide Spacemacs-style key binding wrapping. I would like to add a spacemacs layer guide to README in case that there are other Spacemacs users who need it.
Again, thanks for your work on `org-journal`.