### PR TITLE
Add org-journal-prefix-function

### DIFF
--- a/README.org
+++ b/README.org
@@ -124,7 +124,8 @@ Customization options related to journal directory and files:
 Customization options related to the journal file contents:
 
 - =org-journal-date-format= - date format format =org-journal= uses when showing a
-  date within a journal and search results page.
+  date within a journal and search results page. If set to a function, it is evaluated 
+  and inserted.
 
 - =org-journal-date-prefix= - this string will prefix the date at the top of a journal
   file.

--- a/org-journal.el
+++ b/org-journal.el
@@ -134,7 +134,8 @@ org-journal. Use org-journal-file-format instead.")
 (defcustom org-journal-date-format "%A, %x"
   "Format string for date, by default \"WEEKDAY, DATE\", where
   DATE is what Emacs thinks is an appropriate way to format days
-  in your language."
+  in your language. If you define it as a function, it is evaluated
+  and inserted."
   :type 'string :group 'org-journal)
 
 (defcustom org-journal-date-prefix "* "
@@ -271,8 +272,10 @@ Whenever a journal entry is created the
 
       ;; empty file? Add a date timestamp
       (when new-file-p
-        (insert org-journal-date-prefix
-                (format-time-string org-journal-date-format time)))
+        (if (functionp org-journal-date-format)
+            (insert (funcall org-journal-date-format time))
+          (insert org-journal-date-prefix
+                  (format-time-string org-journal-date-format time))))
 
       ;; add crypt tag if encryption is enabled and tag is not present
       (when org-journal-enable-encryption


### PR DESCRIPTION
This to fix https://github.com/bastibe/org-journal/issues/80.

Now user can set custom functions for prefix. E.g.:
```emacs-lisp
  (defun psamim-journal-prefix()
    (concat
     "* "
     (format-time-string "%B %e, %Y") "\n"
     (format-time-string "%A") "\n"
     (calendar-persian-date-string) "\n"
     (calendar-bahai-date-string) "\n\n"))

  (custom-set-variables
   '(org-journal-prefix-function 'psamim-journal-prefix))
```