### PR TITLE
fix org-journal-dir issue

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -70,7 +70,7 @@ org-journal. Use org-journal-file-format instead.")
 (defun org-journal-update-auto-mode-alist ()
   "Update auto-mode-alist to open journal files in
   org-journal-mode"
-  (let ((name (concat (expand-file-name org-journal-dir)
+  (let ((name (concat (expand-file-name (file-name-as-directory org-journal-dir))
                       (substring org-journal-file-pattern 1))))
     (add-to-list 'auto-mode-alist
                  (cons name 'org-journal-mode))))
@@ -242,7 +242,7 @@ Otherwise, date ascending."
 If no TIME is given, uses the current time."
   (expand-file-name
    (format-time-string org-journal-file-format time)
-   org-journal-dir))
+   (file-name-as-directory org-journal-dir)))
 
 (defun org-journal-dir-check-or-create ()
   "Check existence of `org-journal-dir'. If it doesn't exist, try to make directory."


### PR DESCRIPTION
Currently if `org-journal-dir` does not end in a directory separator (`/`) it will not add the journals to `auto-mode-alist`. There are other org directory variables (such as `org-directory`) that don't have the trailing directory separator, which makes this behavior unexpected. 

This fix will also correctly address #53, which isn't related to auto-loading.
