### PR TITLE
Fix org-extend-today-until timestamp problems, add new option for post-midnight timestamps

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -287,65 +287,72 @@ Whenever a journal entry is created the
 
   ;; if time is before org-extend-today-until, interpret it as
   ;; part of the previous day:
-  (let ((now (decode-time nil)))
-    (if (and (not time) ; time was not given
-             (< (nth 2 now)
-                org-extend-today-until))
-        (setq time (encode-time (nth 0 now)      ; second
-                                (nth 1 now)      ; minute
-                                (nth 2 now)      ; hour
-                                (1- (nth 3 now)) ; day
-                                (nth 4 now)      ; month
-                                (nth 5 now)      ; year
-                                (nth 8 now)))))  ; timezone
+  (let ((oetu-active-p nil))
+    (let ((now (decode-time nil)))
+      (if (and (not time) ; time was not given
+               (< (nth 2 now)
+                  org-extend-today-until))
+          (setq oetu-active-p t
+                time (encode-time (nth 0 now)      ; second
+                                  (nth 1 now)      ; minute
+                                  (nth 2 now)      ; hour
+                                  (1- (nth 3 now)) ; day
+                                  (nth 4 now)      ; month
+                                  (nth 5 now)      ; year
+                                  (nth 8 now)))))  ; timezone
 
-  (let* ((entry-path (org-journal-get-entry-path time))
-         (should-add-entry-p (not prefix)))
+    (let* ((entry-path (org-journal-get-entry-path time))
+           (should-add-entry-p (not prefix)))
 
-    ;; open journal file
-    (unless (string= entry-path (buffer-file-name))
-      (funcall org-journal-find-file entry-path))
-    (org-journal-decrypt)
-    (goto-char (point-max))
-    (let ((new-file-p (equal (point-max) 1)))
+      ;; open journal file
+      (unless (string= entry-path (buffer-file-name))
+        (funcall org-journal-find-file entry-path))
+      (org-journal-decrypt)
+      (goto-char (point-max))
+      (let ((new-file-p (equal (point-max) 1)))
 
-      ;; empty file? Add a date timestamp
-      (when new-file-p
-        (if (functionp org-journal-date-format)
-            (insert (funcall org-journal-date-format time))
-          (insert org-journal-date-prefix
-                  (format-time-string org-journal-date-format time))))
+        ;; empty file? Add a date timestamp
+        (when new-file-p
+          (if (functionp org-journal-date-format)
+              (insert (funcall org-journal-date-format time))
+              (insert org-journal-date-prefix
+                      (format-time-string org-journal-date-format time))))
 
-      ;; add crypt tag if encryption is enabled and tag is not present
-      (when org-journal-enable-encryption
-        (goto-char (point-min))
-        (unless (member org-crypt-tag-matcher (org-get-tags))
-          (org-set-tags-to org-crypt-tag-matcher))
-        (goto-char (point-max)))
+        ;; add crypt tag if encryption is enabled and tag is not present
+        (when org-journal-enable-encryption
+          (goto-char (point-min))
+          (unless (member org-crypt-tag-matcher (org-get-tags))
+            (org-set-tags-to org-crypt-tag-matcher))
+          (goto-char (point-max)))
 
-      ;; move TODOs from previous day here
-      (when (and org-journal-carryover-items
-                 (string= entry-path (org-journal-get-entry-path (current-time))))
-        (save-excursion (org-journal-carryover)))
+        ;; move TODOs from previous day here
+        (when (and org-journal-carryover-items
+                   (string= entry-path (org-journal-get-entry-path (current-time))))
+          (save-excursion (org-journal-carryover)))
 
-      ;; insert the header of the entry
-      (when should-add-entry-p
-        (unless (eq (current-column) 0) (insert "\n"))
-        (let ((timestamp (if (= (time-to-days (current-time)) (time-to-days time))
-                             (format-time-string org-journal-time-format)
-                           "")))
-          (insert "\n" org-journal-time-prefix timestamp))
-        (run-hooks 'org-journal-after-entry-create-hook))
+        ;; insert the header of the entry
+        (when should-add-entry-p
+          (unless (eq (current-column) 0) (insert "\n"))
+          (let* ((day-discrepancy (- (time-to-days (current-time)) (time-to-days time)))
+                 (timestamp (cond ((= day-discrepancy 0)
+                                   (format-time-string org-journal-time-format))
+                                  ((and (= day-discrepancy 1) oetu-active-p)
+                                   (format-time-string org-journal-time-format))
+                                  ;; TODO: option for different timestamp format
+                                  ;; when post-midnight with org-extend-day-until
+                                  (t ""))))
+            (insert "\n" org-journal-time-prefix timestamp))
+          (run-hooks 'org-journal-after-entry-create-hook))
 
-      ;; switch to the outline, hide subtrees
-      (org-journal-mode)
-      (if (and org-journal-hide-entries-p (org-journal-time-entry-level))
-          (outline-hide-sublevels (org-journal-time-entry-level))
-        (outline-show-all))
+        ;; switch to the outline, hide subtrees
+        (org-journal-mode)
+        (if (and org-journal-hide-entries-p (org-journal-time-entry-level))
+            (outline-hide-sublevels (org-journal-time-entry-level))
+            (outline-show-all))
 
-      ;; open the recent entry when the prefix is given
-      (when should-add-entry-p
-        (outline-show-entry)))))
+        ;; open the recent entry when the prefix is given
+        (when should-add-entry-p
+          (outline-show-entry))))))
 
 (defun org-journal-carryover ()
   "Moves all items matching org-journal-carryover-items from the


### PR DESCRIPTION
This fixes issue #61 completely, by changing the “if” that decides whether or not an entry gets a timestamp to a “cond” that decides which kind of timestamp the entry should have (if any).

New local variables are added inside “org-journal-new-entry”:
“oetu-active-p”: Whether or not “org-extend-today-until” is being invoked—this required a big let statement around the entire function contents, and as a result the indentation is changed for the whole function.
“day-discrepancy”: The value of “(- (time-to-days (current-time)) (time-to-days time))”, established so that this check won’t need to be run for each cond clause, and it makes the code a little more readable.

New option “org-journal-time-format-post-midnight” allows the user to establish a different timestamp format for after midnight (when using “org-extend-today-until”), if desired.

…Not sure why the commits are credited to “Tina Russell and Tina Russell” in GitHub, with neither linking to my profile, weird. I’m, uh, new at this. But, I’ve tested the code thoroughly and it’s ready to go!