### PR TITLE
A logo/icon for org-journal

### DIFF
--- a/org-journal.svg
+++ b/org-journal.svg
@@ -1,0 +1,912 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   sodipodi:docname="org-journal.svg"
+   viewBox="0 0 137.939 137.93899"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   width="137.939"
+   height="137.939"
+   inkscape:export-filename="/mnem/Hephaistos/images/creation/org-journal/org-journal_16.png"
+   inkscape:export-xdpi="11.14"
+   inkscape:export-ydpi="11.14">
+  <title
+     id="title1157">Org-Journal icon</title>
+  <defs
+     id="defs4">
+    <filter
+       id="filter3788"
+       height="1.2"
+       width="1.2"
+       y="-0.1"
+       x="-0.1"
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur3790"
+         stdDeviation="12.24"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       id="linearGradient4143"
+       y2="476.35999"
+       gradientUnits="userSpaceOnUse"
+       x2="515.65997"
+       y1="727.91998"
+       x1="516.44"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.41341,0,0,0.3501612,-127.93,-40.076715)">
+      <stop
+         id="stop4013"
+         style="stop-color:#000000;stop-opacity:.46948"
+         offset="0" />
+      <stop
+         id="stop4015"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1091">
+      <rect
+         style="fill:#551400;fill-opacity:1;stroke:none;stroke-width:18.72900009;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect1093"
+         width="5.9191685"
+         height="7.2956548"
+         x="15.878797"
+         y="165.2556" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1098">
+      <rect
+         style="fill:#551400;fill-opacity:1;stroke:none;stroke-width:18.72900009;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect1100"
+         width="5.9191685"
+         height="7.2956548"
+         x="15.878797"
+         y="165.2556" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4143"
+       id="linearGradient1102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41341,0,0,0.3501612,-127.93,-40.076715)"
+       x1="516.44"
+       y1="727.91998"
+       x2="515.65997"
+       y2="476.35999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4143"
+       id="linearGradient1178"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41341,0,0,0.3501612,-127.93,-40.076715)"
+       x1="516.44"
+       y1="727.91998"
+       x2="515.65997"
+       y2="476.35999" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     bordercolor="#666666"
+     inkscape:pageshadow="2"
+     inkscape:window-y="0"
+     fit-margin-left="5.85626"
+     pagecolor="#ffffff"
+     inkscape:window-height="720"
+     inkscape:window-maximized="1"
+     inkscape:zoom="1"
+     inkscape:window-x="0"
+     showgrid="false"
+     borderopacity="1.0"
+     inkscape:current-layer="layer1"
+     inkscape:cx="65.027159"
+     inkscape:cy="68.969521"
+     fit-margin-top="0"
+     fit-margin-right="5.856265"
+     fit-margin-bottom="0"
+     inkscape:window-width="1366"
+     inkscape:pageopacity="0"
+     inkscape:document-units="px"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:object-paths="true"
+     inkscape:measure-start="177.223,82.6686"
+     inkscape:measure-end="180.412,82.6686"
+     units="px"
+     inkscape:snap-global="true">
+    <sodipodi:guide
+       position="5.8548546,12.213452"
+       orientation="0,1"
+       id="guide236"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <g
+     id="layer1"
+     inkscape:label="Cover"
+     inkscape:groupmode="layer"
+     transform="translate(-10.022537,-44.067024)"
+     style="display:inline">
+    <rect
+       x="15.878797"
+       y="44.067024"
+       width="126.22647"
+       height="137.939"
+       ry="8.2322903"
+       style="display:none;fill:#000000;fill-rule:evenodd;stroke-width:0.38047358;filter:url(#filter3788)"
+       id="rect4055"
+       rx="8.2322903" />
+    <rect
+       x="139.46358"
+       y="57.101902"
+       width="5.5074477"
+       height="34.341557"
+       ry="1.9438539"
+       style="fill:#77aa99;fill-opacity:1;fill-rule:evenodd;stroke-width:0.41341001"
+       id="rect4019"
+       rx="1.9438539" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#81aa4e;fill-opacity:1;fill-rule:evenodd;stroke-width:0.41341001"
+       d="m 139.46359,91.220637 v 17.337173 c 0,0.62644 0.86097,1.13477 1.93786,1.13477 h 1.61486 c 1.07689,0 1.9508,-0.50833 1.9508,-1.13477 V 91.220637 c 0,0.62644 -0.87387,1.127245 -1.9508,1.127245 h -1.61486 c -1.07689,0 -1.93786,-0.500805 -1.93786,-1.127245 z"
+       id="rect4021" />
+    <path
+       d="M 139.46359,109.47682 V 126.814 c 0,0.62644 0.86097,1.13477 1.93786,1.13477 h 1.61486 c 1.07689,0 1.9508,-0.50833 1.9508,-1.13477 v -17.33718 c 0,0.62644 -0.87387,1.12725 -1.9508,1.12725 h -1.61486 c -1.07689,0 -1.93786,-0.50081 -1.93786,-1.12725 z"
+       inkscape:connector-curvature="0"
+       style="fill:#a04d32;fill-opacity:1;fill-rule:evenodd;stroke-width:0.41341001"
+       id="path4026" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#aa4e6d;fill-opacity:1;fill-rule:evenodd;stroke-width:0.41341001"
+       d="m 139.46359,127.72887 v 13.0803 c 0,0.47261 0.86097,0.85613 1.93786,0.85613 h 1.61486 c 1.07689,0 1.9508,-0.38351 1.9508,-0.85613 v -13.0803 c 0,0.47262 -0.87387,0.85047 -1.9508,0.85047 h -1.61486 c -1.07689,0 -1.93786,-0.37785 -1.93786,-0.85047 z"
+       id="path4032" />
+    <rect
+       x="15.878797"
+       y="44.067024"
+       width="126.22647"
+       height="137.939"
+       ry="8.2322893"
+       style="fill:#551400;fill-opacity:1;fill-rule:evenodd;stroke-width:0.38047358"
+       id="rect2985"
+       rx="8.2322893" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#801e00;fill-opacity:1;fill-rule:evenodd;stroke-width:0.37095353"
+       sodipodi:nodetypes="csssscc"
+       d="m 28.859877,56.06061 h 96.370003 c 4.85922,0 8.77132,3.033328 8.77132,6.801272 V 163.21834 c 0,3.76795 -3.91206,6.80127 -8.77132,6.80127 H 28.859877 Z"
+       id="rect3983" />
+    <rect
+       x="15.878797"
+       y="44.067024"
+       width="126.22647"
+       height="137.939"
+       ry="8.2322893"
+       style="fill:url(#linearGradient1178);fill-rule:evenodd;stroke-width:0.38047358"
+       id="rect4009"
+       rx="8.2322893" />
+    <rect
+       x="15.878797"
+       y="44.067024"
+       width="126.22647"
+       height="137.939"
+       ry="8.2322893"
+       style="opacity:0.046948;fill:#ffffff;fill-rule:evenodd;stroke-width:0.38047358"
+       id="rect4053"
+       rx="8.2322893" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Binding"
+     transform="translate(-6.2823358,-37.055724)"
+     style="display:inline">
+    <g
+       id="g1155">
+      <g
+         id="g1365">
+        <circle
+           r="2.2679095"
+           cy="54.237236"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3823" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="59.862881"
+           sodipodi:cy="-7.212204"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 63.321355,-1.1787056 A 4.4405093,9.6195068 0 0 1 57.934997,1.4534005 4.4405093,9.6195068 0 0 1 55.529627,-9.3136709"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3825" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,41.567809)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77460766;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3827" />
+      </g>
+      <g
+         id="g1360">
+        <circle
+           r="2.2679095"
+           cy="62.488071"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3831" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="68.178452"
+           sodipodi:cy="-5.7892962"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 71.636925,0.24420224 A 4.4405093,9.6195068 0 0 1 66.250568,2.8763083 4.4405093,9.6195068 0 0 1 63.845198,-7.890763"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3833" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,49.818645)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3835" />
+      </g>
+      <g
+         id="g1355">
+        <circle
+           r="2.2679095"
+           cy="70.738495"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3839" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="76.493607"
+           sodipodi:cy="-4.3664598"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 79.95208,1.6670385 A 4.4405093,9.6195068 0 0 1 74.565723,4.2991446 4.4405093,9.6195068 0 0 1 72.160353,-6.4679267"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3841" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,58.069069)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3843" />
+      </g>
+      <g
+         id="g1350">
+        <circle
+           r="2.2679095"
+           cy="78.987267"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3847" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="84.807098"
+           sodipodi:cy="-2.9439085"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 88.265572,3.0895899 A 4.4405093,9.6195068 0 0 1 82.879215,5.721696 4.4405093,9.6195068 0 0 1 80.473844,-5.0453753"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3849" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,66.317838)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3851" />
+      </g>
+      <g
+         id="g1345">
+        <circle
+           r="2.2679095"
+           cy="87.23893"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3855" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="93.123505"
+           sodipodi:cy="-1.5208582"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 96.581978,4.5126402 A 4.4405093,9.6195068 0 0 1 91.195621,7.1447463 4.4405093,9.6195068 0 0 1 88.790251,-3.6223251"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3857" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,74.569502)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3859" />
+      </g>
+      <g
+         id="g1340">
+        <circle
+           r="2.2679095"
+           cy="95.490593"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3863" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="101.43991"
+           sodipodi:cy="-0.097807743"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 104.89838,5.9356907 A 4.4405093,9.6195068 0 0 1 99.512028,8.5677967 4.4405093,9.6195068 0 0 1 97.106657,-2.1992746"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3865" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,82.821166)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3867" />
+      </g>
+      <g
+         id="g1335">
+        <circle
+           r="2.2679095"
+           cy="103.74226"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3871" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="109.75632"
+           sodipodi:cy="1.3252425"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 113.21479,7.3587409 A 4.4405093,9.6195068 0 0 1 107.82843,9.990847 4.4405093,9.6195068 0 0 1 105.42306,-0.77622437"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3873" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,91.072829)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3875" />
+      </g>
+      <g
+         id="g1330">
+        <circle
+           r="2.2679095"
+           cy="111.99392"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3879" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="118.07272"
+           sodipodi:cy="2.7482929"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 121.5312,8.7817913 A 4.4405093,9.6195068 0 0 1 116.14484,11.413897 4.4405093,9.6195068 0 0 1 113.73947,0.64682603"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3881" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,99.324493)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3883" />
+      </g>
+      <g
+         id="g1325">
+        <circle
+           r="2.2679095"
+           cy="120.24145"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3887" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="126.38496"
+           sodipodi:cy="4.17063"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="M 129.84343,10.204128 A 4.4405093,9.6195068 0 0 1 124.45707,12.836234 4.4405093,9.6195068 0 0 1 122.0517,2.0691631"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3889" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,107.57202)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3891" />
+      </g>
+      <g
+         id="g1320">
+        <circle
+           r="2.2679095"
+           cy="128.49312"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3895" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="134.70137"
+           sodipodi:cy="5.5936813"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="m 138.15984,11.62718 a 4.4405093,9.6195068 0 0 1 -5.38635,2.632106 4.4405093,9.6195068 0 0 1 -2.40537,-10.7670716"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3897" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,115.82369)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3899" />
+      </g>
+      <g
+         id="g1315">
+        <circle
+           r="2.2679095"
+           cy="136.74478"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3903" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="143.01778"
+           sodipodi:cy="7.0167308"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="m 146.47625,13.050229 a 4.4405093,9.6195068 0 0 1 -5.38636,2.632106 4.4405093,9.6195068 0 0 1 -2.40537,-10.7670711"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3905" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,124.07535)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3907" />
+      </g>
+      <g
+         id="g1310">
+        <circle
+           r="2.2679095"
+           cy="144.99644"
+           cx="18.677446"
+           style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+           id="path3911" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="151.33417"
+           sodipodi:cy="8.4397802"
+           transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+           sodipodi:open="true"
+           d="m 154.79264,14.473279 a 4.4405093,9.6195068 0 0 1 -5.38636,2.632106 4.4405093,9.6195068 0 0 1 -2.40537,-10.7670717"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+           sodipodi:ry="9.6195068"
+           sodipodi:rx="4.4405093"
+           id="path3913" />
+        <path
+           sodipodi:start="0.67797216"
+           sodipodi:end="3.3618276"
+           sodipodi:cx="191.99962"
+           sodipodi:cy="270.15967"
+           transform="matrix(0.01383973,0.07975506,-0.16490511,0.00669311,59.334685,132.32701)"
+           sodipodi:open="true"
+           d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+           sodipodi:type="arc"
+           style="fill:none;stroke:#ffffff;stroke-width:10.77700043;stroke-linecap:round;filter:url(#filter3788)"
+           sodipodi:ry="58.285599"
+           sodipodi:rx="54.857033"
+           id="path3915" />
+      </g>
+      <circle
+         id="path3815"
+         style="fill:#ffffff;fill-rule:evenodd;stroke-width:0.48232546"
+         cx="18.677507"
+         cy="153.24397"
+         r="2.2679095" />
+      <path
+         id="path3817"
+         sodipodi:rx="4.4405093"
+         sodipodi:ry="9.6195068"
+         style="fill:none;stroke:#796958;stroke-width:2.90646362;stroke-linecap:round;stroke-opacity:1"
+         sodipodi:type="arc"
+         d="m 163.1049,15.895557 a 4.4405093,9.6195068 0 0 1 -5.38636,2.632106 4.4405093,9.6195068 0 0 1 -2.40537,-10.7670712"
+         sodipodi:open="true"
+         transform="matrix(0.17097285,0.98527574,-0.99917734,0.04055425,0,0)"
+         sodipodi:cy="9.8620586"
+         sodipodi:cx="159.64642"
+         sodipodi:end="3.3618276"
+         sodipodi:start="0.67797216" />
+      <path
+         id="path3819"
+         sodipodi:rx="54.857033"
+         sodipodi:ry="58.285599"
+         style="fill:none;stroke:#ffffff;stroke-width:10.5133543;stroke-linecap:round;filter:url(#filter3788)"
+         sodipodi:type="arc"
+         d="m 234.72481,306.71727 a 54.857033,58.285599 0 0 1 -66.54182,15.9482 54.857033,58.285599 0 0 1 -29.7154,-65.23881"
+         sodipodi:open="true"
+         transform="matrix(0.01383973,0.08380529,-0.16490511,0.00703301,59.334745,139.92814)"
+         sodipodi:cy="270.15967"
+         sodipodi:cx="191.99962"
+         sodipodi:end="3.3618276"
+         sodipodi:start="0.67797216" />
+    </g>
+    <rect
+       y="157.99396"
+       x="12.138597"
+       height="7.5459924"
+       width="5.9191685"
+       id="rect1086"
+       style="fill:#551400;fill-opacity:1;stroke:none;stroke-width:18.72900009;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       transform="matrix(1,0,0,1.0343133,-3.7402004,-12.932104)"
+       id="rect1095"
+       style="display:inline;fill:url(#linearGradient1102);fill-rule:evenodd;stroke-width:0.37410927"
+       ry="7.9591842"
+       height="137.939"
+       width="126.22647"
+       y="44.067024"
+       x="15.878797"
+       clip-path="url(#clipPath1098)"
+       rx="8.2322893" />
+    <rect
+       transform="matrix(0.99997154,0,0,1.0343133,-3.7397485,-12.932104)"
+       id="rect1088"
+       style="display:inline;opacity:0.046948;fill:#ffffff;fill-rule:evenodd;stroke-width:0.37411457"
+       ry="7.9591842"
+       height="137.939"
+       width="126.22647"
+       y="44.067024"
+       x="15.878797"
+       clip-path="url(#clipPath1091)"
+       rx="8.2325239" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Unicorn"
+     style="display:inline"
+     transform="translate(-6.2823358,-37.055724)">
+    <g
+       id="g183"
+       transform="matrix(0.6897526,0,0,0.6897526,27.693509,51.007642)">
+      <path
+         id="path117"
+         d="m 141.044,59.449 c -0.205,-3.15 -2.842,-4.366 -5.993,-2.125 -7.219,-1.297 -14.305,-0.687 -17.8,-0.981 -7.662,-1.073 -14.041,-5.128 -14.041,-5.128 0.932,-1.239 0.486,-3.917 -5.498,-4.101 -1.646,-0.542 -3.336,-1.327 -4.933,-1.979 0.544,-1.145 -0.133,-2.836 -0.133,-2.836 2.435,-0.672 2.808,-3.842 1.848,-5.709 3.106,0.084 2.612,-4.718 2.183,-6.381 2.435,-0.923 2.771,-3.831 1.763,-6.129 2.938,-0.671 3.022,-4.114 2.771,-6.548 3.022,-0.168 2.603,-5.457 2.603,-6.549 2.604,-1.679 2.016,-3.946 2.425,-6.573 1.605,-3.25 -0.577,-4.173 -2.116,-0.71 -1.651,3.001 -3.769,4.311 -3.75,6.528 0.755,1.259 -5.625,3.106 -3.61,7.052 -1.428,1.763 -4.785,4.03 -3.592,6.733 -0.606,1.326 -4.888,4.433 -3.041,7.371 -4.029,2.687 -3.789,3.335 -2.938,5.793 -1.147,0.736 -2.318,1.862 -2.995,3.094 -1.319,-1.568 -2.603,-4.429 -2.584,-8.294 0,-3.275 -6.099,0.318 -6.099,6.784 0,0.556 -0.057,1.061 -0.135,1.542 -2.11,0.243 -4.751,0.707 -8.08,1.494 -0.106,0.073 -0.157,0.186 -0.182,0.316 C 66.986,41.628 66.886,41.112 66.84,40.56 66.258,36.77 61.906,31 59.783,38.126 c -1.096,2.611 -1.74,4.392 -2.115,5.789 v 0 c 0,0 -0.336,0.226 -0.957,0.61 -2.619,1.622 -3.562,6.686 -13.075,9.883 -3.211,1.079 -7.4,1.945 -12.959,2.395 -9.57,0.773 -27.888,17.314 -29.115,33.097 -0.283,3.964 0.31,13.737 3.596,22.31 0.002,0.006 0.003,0.014 0.005,0.02 0.015,0.042 0.032,0.081 0.048,0.122 0.052,0.134 0.103,0.267 0.156,0.398 0.28,0.718 0.579,1.405 0.895,2.062 1.885,4.028 4.46,7.59 7.934,9.882 1.764,1.376 3.342,2.258 4.372,2.762 5.907,9.749 18.442,22.252 42.075,14.859 36.255,-10.284 56.263,13.809 58.568,15.5 3.399,3.433 -8.786,-29.835 -34.587,-44.788 -15.253,-8.322 -5.678,-22.656 -4.585,-27.718 0,0 12.227,8.557 21.087,-4.52 8.004,2.062 13.367,-1.462 20.251,1.03 4.183,1.833 21.77,0.726 15.234,-9.104 4.11,-2.683 4.544,-1.815 6.6,-5.9 1.104,-4.952 -1.403,-6.012 -2.167,-7.366 z M 70.751,46.15 c -0.041,0.018 -0.086,0.04 -0.125,0.056 0.039,-0.034 0.075,-0.062 0.115,-0.102 0.003,0.014 0.007,0.032 0.01,0.046 z m -13.413,4.523 c -0.073,0.429 -0.143,0.829 -0.212,1.216 0.037,-0.832 0.085,-1.714 0.143,-2.646 0.024,0.435 0.05,0.904 0.069,1.43 z M 68.031,44.34 c 0.746,1.124 1.662,2.179 1.662,2.179 0,0 -0.875,-0.79 -1.662,-2.179 z"
+         inkscape:connector-curvature="0"
+         style="fill:#a04d32;stroke:#000000;stroke-width:3" />
+      <path
+         id="path119"
+         d="m 14.093,117.635 c 0,0 10.021,36.105 46.549,24.68 36.255,-10.284 56.263,13.809 58.568,15.5 3.399,3.433 -8.786,-29.835 -34.587,-44.788 -15.253,-8.322 -5.678,-22.656 -4.585,-27.718 0,0 12.227,8.557 21.087,-4.52 8.004,2.062 13.367,-1.462 20.251,1.03 4.183,1.833 21.77,0.726 15.234,-9.104 4.11,-2.683 4.544,-1.815 6.6,-5.9 1.105,-4.952 -1.402,-6.011 -2.166,-7.366 -0.205,-3.15 -2.842,-4.366 -5.993,-2.125 -7.219,-1.297 -14.305,-0.687 -17.8,-0.981 -7.662,-1.073 -14.041,-5.128 -14.041,-5.128 0.932,-1.239 0.486,-3.917 -5.498,-4.101 -3.287,-1.082 -6.752,-3.136 -9.288,-3.162 -2.567,0 -2.914,-2.537 -2.914,-2.537 -1.606,-0.87 -3.924,-4.252 -3.899,-9.438 0,-3.275 -6.099,0.318 -6.099,6.784 0,6.466 -5.818,7.758 -5.818,7.758 0,0 -2.549,-2.281 -2.855,-5.958 -0.582,-3.79 -4.934,-9.56 -7.057,-2.434 -3.226,7.646 -3.485,9.43 -4.115,13.154 -1.31,7.711 -0.345,8.012 -0.345,8.012 l -32.824,23.43 z"
+         inkscape:connector-curvature="0"
+         style="fill:#77aa99;stroke:#000000;stroke-width:0.5" />
+      <path
+         id="path121"
+         d="m 91.756,56.215 c 1.548,-0.562 0.896,-0.415 1.152,-0.581 -2.959,0.575 -9.635,0.614 -14.317,-1.133 0.392,0.23 2.568,0.962 2.845,1.128 0.218,0.715 0.1,1.438 2.932,2.709 2.559,0.793 5.845,0.461 6.835,-0.529 0.109,-1.684 0.126,-1.065 0.553,-1.594 z"
+         inkscape:connector-curvature="0"
+         style="fill:#314b49;stroke:#314b49;stroke-width:0.75;stroke-linecap:round;stroke-linejoin:round" />
+      <path
+         id="path123"
+         d="m 124.124,75.361 c -2.829,-2.085 -4.881,-0.264 -6.469,-0.413 0.99,-0.645 3.762,-2.062 8.245,-2.062 2.532,0 3.879,2.196 5.57,2.207 1.141,0.007 4.472,-1.71 5.14,-2.378 -0.969,0.838 0.454,1.755 -0.489,3.003 -0.282,0.359 -0.837,1.511 -2.663,2.051 -2.05,0.971 -5.411,1.762 -9.334,-2.408 z"
+         inkscape:connector-curvature="0"
+         style="fill:#314b49;stroke:#314b49;stroke-width:0.5" />
+      <path
+         id="path125"
+         d="m 62.577,37.415 c 0,0 -3.355,7.996 0.312,15.329 3.667,7.333 0.522,-6.829 4.688,-4.162 3.397,0.385 -2.387,-3.215 -2.033,-7.819 -0.176,-2.892 -1.77,-5.194 -2.967,-3.348 z"
+         inkscape:connector-curvature="0"
+         style="fill:#314b49" />
+      <path
+         id="path127"
+         d="m 126.981,63.799 c 0,1.121 -1.363,2.03 -3.045,2.03 3.573,-1.121 -0.201,-4.653 -3.045,-2.03 0,-1.121 1.363,-2.03 3.045,-2.03 1.682,0 3.045,0.909 3.045,2.03 z"
+         inkscape:connector-curvature="0"
+         style="fill:#314b49" />
+      <path
+         id="path129"
+         d="m 121.814,61.215 c 3.772,-0.231 6.336,0.323 5.536,3.138 0.548,-1.126 1.292,-2.83 -1.046,-3.507 -1.746,-0.388 -3.299,-0.378 -4.49,0.369 z"
+         inkscape:connector-curvature="0"
+         style="fill:#314b49" />
+      <path
+         id="path131"
+         d="m 67.574,82.616 c 0,-3.521 -1.509,-7.166 -7.04,-14.583 -1.635,-2.192 -2.62,-4.336 -3.211,-6.275 -1.401,-3.295 -3.426,-8.019 -0.613,-17.233 0,0 0.621,-0.384 0,0 -2.619,1.622 -3.562,6.686 -13.075,9.883 -3.211,1.079 -7.4,1.945 -12.959,2.395 C 21.107,57.576 2.789,74.117 1.562,89.9 c -0.283,3.964 0.31,13.737 3.596,22.31 0.002,0.006 0.003,0.014 0.005,0.02 0.015,0.042 0.032,0.081 0.048,0.122 0.052,0.134 0.103,0.267 0.156,0.398 0.28,0.718 0.579,1.405 0.895,2.062 1.885,4.028 4.46,7.59 7.934,9.882 3.084,2.404 5.606,3.306 5.606,3.306 -2.588,-3.578 -3.77,-7.562 -2.263,-12.32 0.651,2.637 1.903,4.162 3.646,4.777 -0.615,-1.884 -0.827,-3.549 0,-4.651 2.567,6.734 5.353,9.031 8.171,10.686 -2.631,-4.914 -4.032,-10.005 -3.771,-15.337 2.569,6.028 6.596,9.945 10.56,13.954 -3.78,-5.966 -6.911,-12.104 -6.977,-19.046 1.693,2.778 3.935,4.932 6.6,6.601 -1.683,-2.709 -2.505,-5.51 -2.263,-8.423 4.424,4.945 9.361,6.607 14.332,8.046 -5.197,-3.625 -9.843,-7.537 -12.32,-12.572 2.972,1.464 5.948,1.693 8.926,1.383 -3.706,-1.872 -5.069,-5.252 -5.783,-9.052 5.177,5.279 10.587,8.827 16.091,11.692 -5.456,-5.26 -9.479,-10.65 -11.566,-16.218 2.1,1.18 4.157,1.736 6.16,1.509 -2.766,-3.124 -3.465,-6.182 -4.211,-9.241 2.637,3.916 4.959,6.022 7.103,7.103 -2.189,-4.482 -2.034,-8.432 -0.503,-12.068 2.524,1.675 4.902,4.295 6.915,9.303 0.731,-2.386 -0.447,-6.364 -1.886,-10.56 2.175,0.622 4.779,3.351 8.171,9.932 -0.33,-3.865 -2.139,-7.775 -4.148,-11.692 3.027,3.51 7.557,12.713 6.788,10.81 z"
+         inkscape:connector-curvature="0"
+         style="fill:#a04d32;stroke:#000000;stroke-width:0.5" />
+      <path
+         id="path133"
+         d="m 83.915,43.558 c 0,0 -0.252,7.472 6.717,2.603 3.61,0.084 2.015,-3.862 2.015,-3.862 2.435,-0.672 2.808,-3.842 1.848,-5.709 3.106,0.084 2.612,-4.718 2.183,-6.381 2.435,-0.923 2.771,-3.831 1.763,-6.129 2.938,-0.671 3.022,-4.114 2.771,-6.548 3.022,-0.168 2.603,-5.457 2.603,-6.549 2.604,-1.679 2.016,-3.946 2.425,-6.573 1.605,-3.25 -0.577,-4.173 -2.116,-0.71 -1.651,3.001 -3.769,4.311 -3.75,6.528 0.755,1.259 -5.625,3.106 -3.61,7.052 -1.428,1.763 -4.785,4.03 -3.592,6.733 -0.606,1.326 -4.888,4.433 -3.041,7.371 -4.029,2.687 -3.789,3.335 -2.938,5.793 -2.155,1.38 -4.409,4.131 -3.278,6.381 z"
+         inkscape:connector-curvature="0"
+         style="fill:#796958;stroke:#000000;stroke-width:0.5" />
+      <path
+         id="path135"
+         d="m 101.739,8.295 c 0,0 -0.735,1.324 -0.735,2.133 0,0.809 2.185,0.568 2.927,-0.227 -1.625,0.024 -2.965,0.289 -2.192,-1.906 z"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff" />
+      <path
+         id="path137"
+         d="m 97.478,14.565 c 0,0 -0.812,1.068 -0.183,2.316 0.392,0.98 2.807,0.962 3.549,0.167 -1.625,0.024 -4.14,-0.287 -3.366,-2.483 z"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff" />
+      <path
+         id="path139"
+         d="m 94.343,21.02 c 0,0 -0.998,1.346 -0.492,2.602 0,0.809 2.838,0.956 3.58,0.161 -1.625,0.022 -3.645,-0.489 -3.088,-2.763 z"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff" />
+      <path
+         id="path141"
+         d="m 91.266,28.182 c 0,0 -1.403,1.542 -0.149,2.945 1.438,0.809 3.744,0.049 4.486,-0.746 -1.625,0.022 -4.894,0.076 -4.337,-2.199 z"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff" />
+      <path
+         id="path143"
+         d="m 88.261,33.903 c 0,0 -1.575,1.414 -0.02,3.312 1.438,0.809 4.57,0.198 5.312,-0.597 -1.624,0.024 -5.989,-1.346 -5.292,-2.715 z"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff" />
+      <path
+         id="path145"
+         d="m 85.114,40.644 c 0,0 -1.403,1.542 -0.149,2.945 1.438,0.809 6.036,-0.186 6.778,-0.981 -1.625,0.023 -7.185,0.311 -6.629,-1.964 z"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff" />
+      <path
+         id="path147"
+         d="m 83.997,43.672 c -0.45,-0.45 -0.534,-0.896 -0.367,-1.718 0,0 0.369,-4.107 -16.333,-0.158 -1.072,0.74 2.396,4.722 2.396,4.722 0,0 0.418,0.215 1.047,-0.415 0.253,1.123 0.852,4.081 0.233,4.579 1.245,-0.771 1.868,-1.946 1.676,-4.125 2.122,0.461 3.742,1.64 4.692,3.779 0.304,-1.4 0.603,-2.799 -0.384,-4.126 2.182,0.285 3.88,1.496 5.362,3.124 0.221,-0.933 0.354,-1.883 0,-2.931 1.391,0.473 2.587,1.607 3.71,2.988 0.001,0 0.211,-3.862 -2.032,-5.719 z"
+         inkscape:connector-curvature="0"
+         style="fill:#a04d32;stroke:#000000;stroke-width:0.5" />
+      <path
+         id="path149"
+         d="m 67.975,71.318 c 0,0 6.761,13.59 17.595,13.991 10.834,0.401 10.834,-2.73 10.834,-2.73 0,0 -15.527,3.048 -28.429,-11.261 z"
+         inkscape:connector-curvature="0"
+         style="opacity:0.26000001" />
+      <path
+         id="path151"
+         d="m 71.13,79.012 c 2.279,3.104 4.856,5.221 7.722,6.382 0,0 -7.365,11.108 -3.611,20.023 3.754,8.915 13.125,11.053 23.321,21.249 7.942,7.942 17.158,24.961 17.158,24.961 0,0 -17.834,-14.176 -29.42,-13.479 0,0 -2.687,-9.668 -10.585,-17.566 C 64.471,109.337 59.547,94.707 71.13,79.012 Z"
+         inkscape:connector-curvature="0"
+         style="opacity:0.26000001" />
+      <path
+         id="path153"
+         d="M 52.362,51.627 C 48.488,54.128 43.943,58.723 27.947,59.71 10.898,66.494 0.514,86.395 4.17,100.174 c 1.348,7.317 3.891,14.18 3.891,14.18 -0.887,-5.919 -1.383,-11.397 1.033,-13.599 1.435,2.384 2.969,2.468 4.507,2.479 -1.59,-2.404 -1.788,-4.808 0,-7.212 1.489,1.525 2.992,1.881 4.507,1.353 -2.128,-2.449 -1.867,-4.848 0,-7.211 1.388,5.022 4.462,7.453 7.662,9.689 -2.208,-4.333 -4.166,-8.672 -2.93,-13.07 1.323,0.729 2.595,0.644 3.831,0 -1.257,-1.576 -0.925,-3.153 0,-4.732 2.947,3.04 6.213,3.724 9.465,4.507 -2.661,-2.454 -5.543,-4.527 -6.761,-9.465 1.501,-1.811 3.269,-2.685 5.408,-2.253 -1.901,-1.167 -1.65,-2.543 0,-4.057 2.089,1.104 4.195,1.352 6.31,1.127 -2.807,-1.68 -8.424,-4.994 11.269,-20.283 z"
+         inkscape:connector-curvature="0"
+         style="opacity:0.18000004;fill:#ffffff" />
+      <path
+         id="path155"
+         d="m 78.923,32.771 c 0.996,-0.963 1.146,-0.65 0.854,0.285 -0.982,2.36 0.353,4.647 0.797,6.206 l -3.871,0.114 c 0.108,-2.271 0.247,-4.794 2.22,-6.605 z"
+         inkscape:connector-curvature="0"
+         style="opacity:0.27000002;fill:#ffffff" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Cover details"
+     transform="translate(-6.2823358,-37.055724)"
+     style="display:inline">
+    <g
+       id="g234">
+      <rect
+         rx="4.5756216"
+         id="rect3986"
+         style="opacity:0.42254004;fill:none;stroke:#2b1100;stroke-width:1.19471359;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         ry="4.5756216"
+         height="26.822287"
+         width="67.862289"
+         y="58.667072"
+         x="41.956955" />
+      <g
+         transform="matrix(0.41341,0,0,0.41341,-133.26569,-68.286786)"
+         id="g4004"
+         style="opacity:0.23474001">
+        <rect
+           rx="0.78367001"
+           id="rect3988"
+           style="fill:#ffffff"
+           transform="scale(1,-1)"
+           ry="0.78367001"
+           height="1.5673"
+           width="106.69"
+           y="-331.38"
+           x="472.89001" />
+        <rect
+           rx="0.78367001"
+           id="rect3990"
+           ry="0.78367001"
+           style="fill:#ffffff"
+           transform="scale(1,-1)"
+           height="1.5673"
+           width="107.36"
+           y="-345.88"
+           x="472.54999" />
+      </g>
+      <rect
+         id="rect3994"
+         style="opacity:0.04225398;fill:#cccccc;stroke:#2b1100;stroke-width:0.40892866;stroke-linecap:round;stroke-linejoin:round"
+         ry="0"
+         height="11.620071"
+         width="10.218359"
+         y="65.563179"
+         x="46.583012" />
+    </g>
+  </g>
+  <metadata
+     id="metadata93">
+    <rdf:RDF>
+      <cc:Work>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://www.gnu.org/licenses/gpl-2.0.html" />
+        <dc:publisher>
+          <cc:Agent
+             rdf:about="http://openclipart.org/">
+            <dc:title>Openclipart</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:title>Org-Journal icon</dc:title>
+        <dc:date>2018-12-0</dc:date>
+        <dc:description>Icon/logo for the Emacs “org-journal” mode.
+By Tina Russell, based on original clipart by gsagri04, and incorporating the Org Mode unicorn art by Christophe Bataillon and Greg Newman. (The Org Mode unicorn was originally conceived by Bastien Guerry.)
+The journal clipart is in the public domain, while the unicorn art is licensed under the GNU General Public License version 2 or later, so this image is also licensed under the GNU GPL version 2 or later.
+GPL version 2: http://www.gnu.org/licenses/gpl-2.0.html
+GPL current version: http://www.gnu.org/licenses/gpl.html
+Original clipart: https://openclipart.org/detail/144781/diary-by-gsagri04
+Org Mode unicorn art: https://commons.wikimedia.org/wiki/File:Org-mode-unicorn.svg</dc:description>
+        <dc:source></dc:source>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Tina Russell</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>emacs</rdf:li>
+            <rdf:li>org</rdf:li>
+            <rdf:li>org-mode</rdf:li>
+            <rdf:li>org-journal</rdf:li>
+            <rdf:li>journal</rdf:li>
+            <rdf:li>diary</rdf:li>
+            <rdf:li>unicorn</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Tina Russell, gsagri04, Christophe Bataillon, Greg Newman</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/org-journal.svg
+++ b/org-journal.svg
@@ -107,13 +107,13 @@
      pagecolor="#ffffff"
      inkscape:window-height="720"
      inkscape:window-maximized="1"
-     inkscape:zoom="1"
+     inkscape:zoom="4.0307674"
      inkscape:window-x="0"
      showgrid="false"
      borderopacity="1.0"
      inkscape:current-layer="layer1"
-     inkscape:cx="65.027159"
-     inkscape:cy="68.969521"
+     inkscape:cx="68.969498"
+     inkscape:cy="68.969498"
      fit-margin-top="0"
      fit-margin-right="5.856265"
      fit-margin-bottom="0"
@@ -126,13 +126,7 @@
      inkscape:measure-start="177.223,82.6686"
      inkscape:measure-end="180.412,82.6686"
      units="px"
-     inkscape:snap-global="true">
-    <sodipodi:guide
-       position="5.8548546,12.213452"
-       orientation="0,1"
-       id="guide236"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
+     inkscape:snap-global="true" />
   <g
      id="layer1"
      inkscape:label="Cover"
@@ -884,7 +878,7 @@ GPL version 2: http://www.gnu.org/licenses/gpl-2.0.html
 GPL current version: http://www.gnu.org/licenses/gpl.html
 Original clipart: https://openclipart.org/detail/144781/diary-by-gsagri04
 Org Mode unicorn art: https://commons.wikimedia.org/wiki/File:Org-mode-unicorn.svg</dc:description>
-        <dc:source></dc:source>
+        <dc:source />
         <dc:creator>
           <cc:Agent>
             <dc:title>Tina Russell</dc:title>


### PR DESCRIPTION
I created a scalable logo for org-journal-mode that’s also suitable for use (once appropriately scaled and rendered) as a mode-line or file-type icon. …I wasn’t exactly sure where to put this, so I thought a pull-request would be best. It’s based on [this public-domain clip-art](https://openclipart.org/detail/144781/diary), heavily modified by me both to work as an icon (square proportions) and to incorporate [the Org Mode unicorn art](https://commons.wikimedia.org/wiki/File:Org-mode-unicorn.svg), which is GPLv2+. (I even changed all the colors on the journal art to be harmonious with the unicorn design—it wasn’t easy!)

Feel free to use this wherever you want (documentation, website, this repository, etc., as SVG or rendered as a bitmap of appropriate size). I suppose the next step is to submit a small bitmap version to the mode-icons project, or all-the-icons or something, but I figured I’d start here, first.