### PR TITLE
Add journal file encryption support

### DIFF
--- a/README.org
+++ b/README.org
@@ -186,7 +186,15 @@ match TODO items.
 
 *** Encryption
 
-The journal can be encrypted using =org-crypt= when ~org-journal-enable-encryption~ is non-nil.
+The journal entry can be encrypted using =org-crypt=, to enable it set
+~org-journal-enable-encryption~ to =t=.
+
+You can also encrypt the journal files itself by setting the variable
+~org-journal-encrypt-journal~ to =t=. =org-journal= will always search for
+journal files with the =.gpg= extension, and highlights them in the calendar,
+etc., regardless of the value of ~org-journal-encrypt-journal~.
+See the info page =(info "(epa)Encrypting/decrypting gpg files")= for more
+information about gpg encryption in Emacs.
 
 *** Agenda and Scheduling
 

--- a/org-journal.el
+++ b/org-journal.el
@@ -93,7 +93,7 @@ org-journal. Use org-journal-file-format instead.")
      "%m" "\\\\(?2:[0-9][0-9]\\\\)"
      (replace-regexp-in-string
       "%Y" "\\\\(?1:[0-9]\\\\{4\\\\}\\\\)" format)))
-   "\\'"))
+   "\\(\\.gpg\\)?\\'"))
 
 ; Customizable variables
 (defgroup org-journal nil
@@ -196,6 +196,11 @@ saves/opens these journal entries, emacs asks a user passphrase
 to encrypt/decrypt it."
   :type 'boolean)
 
+(defcustom org-journal-encrypt-journal nil
+  "If non-nil, encrypt journal files using gpg.
+The journal files will have the file extension .gpg"
+  :type 'boolean)
+
 (defcustom org-journal-encrypt-on 'before-save-hook
   "Hook on which to encrypt entries. It can be set to other hooks
   like kill-buffer-hook. "
@@ -273,7 +278,10 @@ Otherwise, date ascending."
 If no TIME is given, uses the current time."
   (file-truename
    (expand-file-name
-    (format-time-string org-journal-file-format time)
+    (format-time-string
+     (concat org-journal-file-format
+             (if org-journal-encrypt-journal ".gpg" ""))
+     time)
     (file-name-as-directory org-journal-dir))))
 
 (defun org-journal-dir-check-or-create ()
@@ -582,7 +590,8 @@ If the date is in the future, create a schedule entry."
   "Read an entry for the TIME and either select the new
   window (NOSELECT is nil) or avoid switching (NOSELECT is
   non-nil."
-  (let ((org-journal-file (org-journal-get-entry-path time)))
+  (let ((org-journal-file (concat (org-journal-get-entry-path time)
+                                  (if org-journal-encrypt-journal ".gpg") "")))
     (if (file-exists-p org-journal-file)
         (progn
           ;; open file in view-mode if not opened already

--- a/org-journal.el
+++ b/org-journal.el
@@ -276,13 +276,13 @@ Otherwise, date ascending."
 (defun org-journal-get-entry-path (&optional time)
   "Return the path to an entry given a TIME.
 If no TIME is given, uses the current time."
-  (file-truename
-   (expand-file-name
-    (format-time-string
-     (concat org-journal-file-format
-             (if org-journal-encrypt-journal ".gpg" ""))
-     time)
-    (file-name-as-directory org-journal-dir))))
+  (let ((file (file-truename
+               (expand-file-name
+                (format-time-string (concat org-journal-file-format) time)
+                (file-name-as-directory org-journal-dir)))))
+    (unless (file-exists-p file)
+      (setq file (concat file ".gpg")))
+    file))
 
 (defun org-journal-dir-check-or-create ()
   "Check existence of `org-journal-dir'. If it doesn't exist, try to make directory."


### PR DESCRIPTION
This change will add journal file encryption. I honestly don't see the point of the :crypt: tag if we can just encrypt the hole file. Anyway, I have not removed this functionality. I created a own commit for this as it has nothing to do with the daily/weekly/monthly/yearly journal file functionality I'm currently working on.

best,
Christian