### PR TITLE
[doc] Fix Spacemacs org-journal support 404 link

### DIFF
--- a/README.org
+++ b/README.org
@@ -357,7 +357,7 @@ variables.
 
 Yes you can!
 
-- To use =org-journal= with Spacemacs from master branch, you must do this:
+- To use =org-journal= with Spacemacs from the =master= branch, you must do this:
 
   1. =git clone https://github.com/borgnix/spacemacs-journal.git ~/.emacs.d/private/journal=
   2. add it to your =~/.spacemacs=. You will need to add =journal= to the
@@ -365,8 +365,8 @@ Yes you can!
 
   The manual of the journal layer can be found at https://github.com/borgnix/spacemacs-journal
 
-- If you use Spacemacs from the develop branch you can enable `org-journal` by
-  setting `org-enable-org-journal-support` to `t`, see [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/%252Bemacs/org#org-journal-support][Spacemacs org-journal support]].
+- If you use Spacemacs from the =develop= branch you can enable =org-journal= by
+  setting =org-enable-org-journal-support= to =t=, see [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/+emacs/org#org-journal-support][Spacemacs org-journal support]].
 
 *** Some key-bindings in org-journal overwrite org-mode key bindings
 


### PR DESCRIPTION
And change the emphasis from ` (grave accents) to = (equal signs).

---

The issue was caused by the url being double encoded as explained in this SO question:
https://stackoverflow.com/questions/13968282/unknown-characters-252b-in-url

>The URL has been double encoded. %25 is the escape sequence for "%", so a regular %2B got escaped again to %252B.

source: https://stackoverflow.com/a/13968361

