### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -108,3 +108,11 @@
   - Fixes issue with encryption, byte-compilation (Thank you, Christian Schwarzgruber!)
   - Improves documentation (Thank you, EFLS!)
   - Fixes initialization error (Thank you, Christian Schwarzgruber!)
+
+## 2019-10-30 V2.0.0
+  - Adds support for weekly, monthly and yearly journal files
+  - Adds cache to speed up calendar operations
+  - Adds support for persistent tags (Thank you, Tina Russell!)
+  - Improves search result buffer
+  - Include start/end date in search result
+  - Adds `org-journal-follow-mode` to follow journal entries when moving between entries in calendar

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,9 +1,10 @@
   Bastian Bechtold - maintainer
+  Christian Schwarzgruber - maintainer
 
   aJchemist
+  Akira Komamura
   Boris Buliga
   charlescharles
-  Christian Schwarzgruber
   David Smith
   Donghyun Cho
   EFLS
@@ -12,6 +13,7 @@
   Miciah Masters
   Puneeth Chaganti
   Ram Raghunathan
+  Rudi Grinberg
   Ruibin Xing
   Samim Pezeshki
   Tina Russell

--- a/README.org
+++ b/README.org
@@ -29,6 +29,10 @@ the journal entry can be encrypted, so can the file, see
 =org-journal-enable-encryption= and =org-journal-encrypt-journal=,
 respectively.
 
+Every journal entry must have a *CREATED* property when using yearly, monthly
+and weekly journal files. This property is added by =org-journal-new-entry=
+automatically.
+
 An example of a daily file (it will actually look a lot nicer, depending on
 your org-mode
 settings):
@@ -340,6 +344,15 @@ as in the following example:
   (setq org-capture-templates '(("j" "Journal entry" entry (function org-journal-find-location)
                                  "* %(format-time-string org-journal-time-format)%^{Title}\n%i%?")))
 #+END_SRC
+
+*** Caching of journal dates
+Since version 2.0.0 a cache has been added to speed up calendar
+operations. This should drastically improve the performance when using
+encrypted journal files, see =org-journal-encrypt-journal=.
+
+The caching functionality can be enabled by settings
+=org-journal-enable-cache= to =t=. The cache can be reset by calling
+=org-journal-invalidate-cache=.
 
 ** FAQ
 

--- a/org-journal-test.el
+++ b/org-journal-test.el
@@ -1,4 +1,4 @@
-;; org-journal-test.el ---
+;; org-journal-test.el --- Test file for org-journal
 ;;
 ;; Author: Christian Schwarzgruber (c.schwarzgruber.cs@gmail.com)
 ;;

--- a/org-journal.el
+++ b/org-journal.el
@@ -1,8 +1,10 @@
 ;;; org-journal.el --- a simple org-mode based journaling mode -*- lexical-binding: t; -*-
 
 ;; Author: Bastian Bechtold
+;;         Christian Schwarzgruber
+
 ;; URL: http://github.com/bastibe/org-journal
-;; Version: 1.15.1
+;; Version: 2.0.0
 ;; Package-Requires: ((emacs "25.1"))
 
 ;;; Commentary:


### PR DESCRIPTION
Hey @bastibe!

Things are getting stable now, so I thought its time for a little version bump. However, there are a couple of things left.

- [x] PR #155 Merge or create a custom implementation which is sufficient for our needs
- [x] Limit org-agenda integration to file scope (yearly, monthly, weekly journal files). Right now every TODO in that file will be included in the agenda, see the TODO in function `org-journal-update-org-agenda-files`
   There is not really an easy way to limit it to current and future journal files containing TODO entries for weekly, monthly and yearly journal files.
- [ ] Wait a couple of weeks to see if the caching functionality needs improvements

EDIT:
Due to some issues with the cache the new release date will be delayed to Friday 2020-01-10