### PR TITLE
Create the directory for org-journal-cache-file

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -860,12 +860,13 @@ file `org-journal-cache-file'."
   "Write hashmap to file."
   (unless (file-directory-p (file-name-directory org-journal-cache-file))
     (make-directory (file-name-directory org-journal-cache-file) t))
-  (when (file-writable-p org-journal-cache-file)
-    (with-temp-file org-journal-cache-file
-      (let (print-length)
-        (insert (prin1-to-string org-journal-dates)
-                "\n"
-                (prin1-to-string org-journal-journals)))))
+  (if (file-writable-p org-journal-cache-file)
+      (with-temp-file org-journal-cache-file
+        (let (print-length)
+          (insert (prin1-to-string org-journal-dates)
+                  "\n"
+                  (prin1-to-string org-journal-journals))))
+    (error "%s is not writable" org-journal-cache-file))
   (org-journal-flatten-dates))
 
 (defun org-journal-deserialize ()

--- a/org-journal.el
+++ b/org-journal.el
@@ -858,6 +858,8 @@ file `org-journal-cache-file'."
 
 (defun org-journal-serialize ()
   "Write hashmap to file."
+  (unless (file-directory-p (file-name-directory org-journal-cache-file))
+    (make-directory (file-name-directory org-journal-cache-file) t))
   (when (file-writable-p org-journal-cache-file)
     (with-temp-file org-journal-cache-file
       (let (print-length)


### PR DESCRIPTION
This patch ensures that the parent directory of `org-journal-cache-file` is created before the file is saved.

It also throws an error if the file is still unwritable.

This was originally pointed by @tarsius while I was trying to add this package to `no-littering`:

https://github.com/emacscollective/no-littering/pull/101