### PR TITLE
Set the customization type of org-journal-dir to directory

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -163,7 +163,7 @@ to be done manually by calling `org-journal-invalidate-cache'."
 Setting this will update the internal `org-journal-file-pattern' to a regex
 that matches the directory, using `org-journal-dir-and-format->regex', and
 update `auto-mode-alist' using `org-journal-update-auto-mode-alist'."
-  :type 'string
+  :type 'directory
   :set (lambda (symbol value)
          (set-default symbol value)
          ;; if org-journal-file-format is not yet bound, we’ll need a default value


### PR DESCRIPTION
`org-journal-dir` currently has `string` type, but it would be slightly better to make it a `directory`, which is defined as follows in the info:

> ‘directory`
>      The value must be a directory.  The widget provides completion.