### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -383,11 +383,20 @@ Yes you can!
 
 *** Some key-bindings in org-journal conflict with org-mode key bindings
 
-Minor modes are supposed to only use key bindings of the form =C-c C-?=, where =?= can be any letter, and to not overwrite major mode bindings. With org-mode already using most interesting keys, collisions are inevitable. Currently, when working in an org-mode buffer the following org-journal key bindings are overwritten:
+Minor modes are supposed to only use key bindings of the form =C-c C-?=, where =?= can be any letter, and to not overwrite major mode bindings. With org-mode already using most interesting keys, collisions are inevitable. This means that some org-journal key bindings will not work as expected in an org-mode buffer, and also that some org-mode key bindings will not work as expected in an org-journal buffer.
+
+When working in an org-mode buffer the following org-journal key bindings are overwritten:
 - =C-c C-s= (=org-journal-search=) with =org-schedule=
 - =C-c C-f= (=org-journal-open-next-entry=) with =org-forward-heading-same-level=
 - =C-c C-b= (=org-journal-open-previous-entry=) with =org-backward-heading-same-level=
 - =C-c C-j= (=org-journal-new-entry=) with =org-goto=
+
+When working in an org-journal buffer the following org-mode key bindings are overwritten:
+- =C-c C-s= (=org-schedule=) with =org-journal-search=
+- =C-c C-f= (=org-forward-heading-same-level=) with =org-journal-open-next-entry=
+- =C-c C-b= (=org-backward-heading-same-level=) with =org-journal-open-previous-entry=
+- =C-c C-j= (=org-goto=) with =org-journal-new-entry=
+
 To workaround this, you can use user bindings of the form =C-c ?=, where =?= can be any letter, to call the org-journal functions. This allows you to have a set of keybindings that work the same in org-mode and org-journal buffers. However, this is Emacs, and if you don't like a key binding, change it!
 
 *** Opening journal entries from the calendar are not editable

--- a/README.org
+++ b/README.org
@@ -383,12 +383,12 @@ Yes you can!
 
 *** Some key-bindings in org-journal conflict with org-mode key bindings
 
-Minor modes are supposed to only use key bindings of the form =C-c C-?=, where =?= can be any letter, and to not overwrite major mode bindings. With org-mode already using most interesting keys, collisions are inevitable. Currently, org-mode overwrites the following org-journal key bindings:
+Minor modes are supposed to only use key bindings of the form =C-c C-?=, where =?= can be any letter, and to not overwrite major mode bindings. With org-mode already using most interesting keys, collisions are inevitable. Currently, when working in an org-mode buffer the following org-journal key bindings are overwritten:
 - =C-c C-s= (=org-journal-search=) with =org-schedule=
 - =C-c C-f= (=org-journal-open-next-entry=) with =org-forward-heading-same-level=
 - =C-c C-b= (=org-journal-open-previous-entry=) with =org-backward-heading-same-level=
 - =C-c C-j= (=org-journal-new-entry=) with =org-goto=
-To workaround this, use user bindings of the form =C-c ?=, where =?= can be any letter. However, this is Emacs, and if you don't like a key binding, change it!
+To workaround this, you can use user bindings of the form =C-c ?=, where =?= can be any letter, to call the org-journal functions. This allows you to have a set of keybindings that work the same in org-mode and org-journal buffers. However, this is Emacs, and if you don't like a key binding, change it!
 
 *** Opening journal entries from the calendar are not editable
 

--- a/README.org
+++ b/README.org
@@ -381,14 +381,14 @@ Yes you can!
 - If you use Spacemacs from the =develop= branch you can enable =org-journal= by
   setting =org-enable-org-journal-support= to =t=, see [[https://github.com/syl20bnr/spacemacs/tree/develop/layers/+emacs/org#org-journal-support][Spacemacs org-journal support]].
 
-*** Some key-bindings in org-journal overwrite org-mode key bindings
+*** Some key-bindings in org-journal conflict with org-mode key bindings
 
-Major modes are supposed to only use key bindings of the form =C-c C-?=, where =?= can be any letter. With org-mode already using most interesting keys, collisions are inevitable. Currently, org-journal overwrites
-- =C-c C-s= (=org-schedule=) with =org-journal-search=
-- =C-c C-f= (=org-forward-heading-same-level=) with =org-journal-open-next-entry=
-- =C-c C-b= (=org-backward-heading-same-level=) with =org-journal-open-previous-entry=
-- =C-c C-j= (=org-goto=) with =org-journal-new-entry=
-However, this is Emacs, and if you don't like a key binding, change it!
+Minor modes are supposed to only use key bindings of the form =C-c C-?=, where =?= can be any letter, and to not overwrite major mode bindings. With org-mode already using most interesting keys, collisions are inevitable. Currently, org-mode overwrites the following org-journal key bindings:
+- =C-c C-s= (=org-journal-search=) with =org-schedule=
+- =C-c C-f= (=org-journal-open-next-entry=) with =org-forward-heading-same-level=
+- =C-c C-b= (=org-journal-open-previous-entry=) with =org-backward-heading-same-level=
+- =C-c C-j= (=org-journal-new-entry=) with =org-goto=
+To workaround this, use user bindings of the form =C-c ?=, where =?= can be any letter. However, this is Emacs, and if you don't like a key binding, change it!
 
 *** Opening journal entries from the calendar are not editable
 


### PR DESCRIPTION
Reword "Some key-bindings in org-journal overwrite org-mode key bindings" to improve clarity.