### PR TITLE
Add org-journal-file-header

### DIFF
--- a/README.org
+++ b/README.org
@@ -217,6 +217,8 @@ Customization options related to the journal file contents:
 
 - =org-journal-time-prefix= - a string that will prefix every entry within a daily journal file.
 
+- org-journal-file-header - a string that will be inserted at the top of every new journal file.
+
 *** An example setup
 
 A very basic example of customization.

--- a/org-journal.el
+++ b/org-journal.el
@@ -311,6 +311,11 @@ search works with regexps."
   "If `t', journal entry dates will be cashed for faster calendar operations."
   :type 'boolean)
 
+(defcustom org-journal-file-header nil
+  "If non-nil, contents will be inserted at the top of new journal files.
+If you define it as a function, it is evaluated and inserted."
+  :type 'string)
+
 (defvar org-journal-after-entry-create-hook nil
   "Hook called after journal entry creation.")
 
@@ -507,6 +512,11 @@ hook is run."
       ;; Open journal file
       (unless (string= entry-path (buffer-file-name))
         (funcall org-journal-find-file entry-path))
+
+      (if (and org-journal-file-header (= (buffer-size) 0))
+          (if (functionp org-journal-file-header)
+              (funcall org-journal-file-header)
+            (insert org-journal-file-header)))
 
       ;; Create new journal entry if there isn't one.
       (let ((entry-header


### PR DESCRIPTION
Fix #182 

This PR adds an `org-journal-file-header` string that is inserted at the top of new journal entries. If the value is a function, the result of evaluating the function is inserted. FWIW, here's my experimental configuration for weekly journals:

```
(defun ndw/org-journal-monday (&optional time)
  "Return the TIME cast back to the previous Monday.
If TIME isn’t specified, the (current-time) is assumed.
If today is Monday, return today."
  (let* ((now    (if time time (current-time)))
         (dow    (string-to-number (format-time-string "%u" now)))
         (delta  (if (= dow 1)
                     0
                   (* (- dow 1) (* 24 3600)))))
    (seconds-to-time (- (time-to-seconds now) delta))))

(customize-set-variable 'org-journal-file-header
   (lambda ()                        
     (let ((monday (ndw/org-journal-monday)))
       (insert "#+TITLE: ")
       (insert (format-time-string org-journal-date-format monday))
       (insert "\n#+STARTUP: showeverything\n#+FILETAGS: :Journal:\n\n"))))
```

