### PR TITLE
Allow changing of weekly journal start day.

### DIFF
--- a/README.org
+++ b/README.org
@@ -182,7 +182,9 @@ Customization options related to journal directory and files:
   will go into the previous day's journal.
 
 - =org-journal-file-type= - the journal file type either 'daily (default),
-  'weekly, 'monthly or 'yearly.
+  'weekly, 'monthly or 'yearly.  Also see the customizable variables
+  =org-journal-start-on-weekday= and =org-journal-use-agenda-start-on-weekday=
+  for changing the start of the week for weekly journals (defaults to Monday).
 
 *** Journal File Content
 

--- a/org-journal.el
+++ b/org-journal.el
@@ -162,10 +162,7 @@ to be done manually by calling `org-journal-invalidate-cache'."
   "What day of the week to start a weekly journal.
 
 When org-journal-file-type is set to 'weekly, start the week on
-this day.  Defaults to Monday.
-
-Not that when org-journal-use-agenda-start-on-weekday is non-NIL,
-the value from org-agenda-start-on-weekday is used instead."
+this day.  Defaults to Monday."
   :type '(choice
 	  (const :tag "Sunday" 0)
 	  (const :tag "Monday" 1)
@@ -174,14 +171,6 @@ the value from org-agenda-start-on-weekday is used instead."
 	  (const :tag "Thursday" 4)
 	  (const :tag "Friday" 5)
 	  (const :tag "Saturday" 6)))
-
-(defcustom org-journal-use-agenda-start-on-weekday nil
-  "When not NIL, weekly journals should start on the same day as the agenda.
-
-When org-journal-file-type is set to 'weekly, use the value of
-org-agenda-start-on-weekday as the first day of the week for
-journal files."
-  :type 'boolean)
 
 (defcustom org-journal-dir "~/Documents/journal/"
   "Directory containing journal entries.
@@ -467,9 +456,7 @@ the first date of the year."
 		      (split-string (format-time-string "%m %d %Y" time) " "))))
 	    (target-date
 	     (+ absolute-monday
-		(if org-journal-use-agenda-start-on-weekday
-		    (- org-agenda-start-on-weekday 1)
-		  (- org-journal-start-on-weekday 1))))
+		(- org-journal-start-on-weekday 1)))
 	    (date
              (calendar-gregorian-from-absolute
               (if (> target-date absolute-now)


### PR DESCRIPTION
Added two customization options org-journal-start-on-weekday
and org-journal-use-agenda-start-on-weekday.  The first changes
the start day of daily journals.  The second tells org-journal
to use the value of org-agenda-start-on-weekday for its start
day.  When the second option is set, the first is ignored.

Do note that established journals will no longer work when the
start day is changed.

Please excuse the indentation bits that were sucked into the diff
(lines 82-89).  Apparently aggressive-indent-mode took issue with
some of the indentation I was scrolling through.  I can create a new
pull request without those, if you like.