### PR TITLE
Use new style created timestamp (Resolve #188)

### DIFF
--- a/org-journal-test.el
+++ b/org-journal-test.el
@@ -51,31 +51,29 @@
 
 (ert-deftest org-journal-calendar-date-from-file ()
   "Should return a list with day/month/year"
-  (org-journal-dir-test-setup)
-  (let* ((org-journal-dir org-journal-dir-test)
-         (org-journal-file-pattern (org-journal-file-pattern-test)))
-    (should (equal (org-journal-file-name->calendar-date
-                    (expand-file-name "20190103" org-journal-dir))
-                   '(1 03 2019)))))
+  (org-journal-test-macro
+   (should (equal (org-journal-file-name->calendar-date
+                   (expand-file-name "20190103" org-journal-dir))
+                  '(1 03 2019)))))
 
 (ert-deftest org-journal-convert-time-to-file-type-time-test ()
   "Testing"
-  (let ((time (current-time))
-        (org-journal-file-type 'daily))
-    (should (equal (org-journal-convert-time-to-file-type-time time)
-                   time))
-    (setq time (encode-time 0 0 0 3 1 2019)
-          org-journal-file-type 'weekly)
-    (should (equal (org-journal-convert-time-to-file-type-time time)
-                   (encode-time 0 0 0 31 12 2018)))
-    (setq time (encode-time 0 0 0 15 4 2019)
-          org-journal-file-type 'monthly)
-    (should (equal (org-journal-convert-time-to-file-type-time time)
-                   (encode-time 0 0 0 1 4 2019)))
-    (setq time (encode-time 0 0 0 3 2 2019)
-          org-journal-file-type 'yearly)
-    (should (equal (org-journal-convert-time-to-file-type-time time)
-                   (encode-time 0 0 0 1 1 2019)))))
+  (org-journal-test-macro
+   (let ((time (current-time)))
+     (should (equal (org-journal-convert-time-to-file-type-time time)
+                    time))
+     (setq time (encode-time 0 0 0 3 1 2019)
+           org-journal-file-type 'weekly)
+     (should (equal (org-journal-convert-time-to-file-type-time time)
+                    (encode-time 0 0 0 31 12 2018)))
+     (setq time (encode-time 0 0 0 15 4 2019)
+           org-journal-file-type 'monthly)
+     (should (equal (org-journal-convert-time-to-file-type-time time)
+                    (encode-time 0 0 0 1 4 2019)))
+     (setq time (encode-time 0 0 0 3 2 2019)
+           org-journal-file-type 'yearly)
+     (should (equal (org-journal-convert-time-to-file-type-time time)
+                    (encode-time 0 0 0 1 1 2019))))))
 
 (ert-deftest org-journal-insert-header ()
   "Test insertion of header"

--- a/org-journal-test.el
+++ b/org-journal-test.el
@@ -44,7 +44,7 @@
           (org-agenda-inhibit-startup t)
           (org-journal-time-format "%R")
           (org-journal-file-header "")
-          (org-journal-created-property-format-type 'ymd))
+          (org-journal-created-property-timestamp-format "%Y%m%d"))
      (org-journal-dir-test-setup)
      ,@body))
 
@@ -98,7 +98,7 @@
        (org-set-property "CREATED" "20190101")
        (insert "** 13:00 Some journal entry\n")
        (insert "* Wednesday, 01/02/19\n")
-       (org-set-property "CREATED" "[2019-01-02 Wed]")
+       (org-set-property "CREATED" "20190102")
        (insert "** TODO First\n")
        (insert "** 13:00 Some journal entry 1\n")
        (insert "** TODO Second\n")
@@ -126,7 +126,7 @@
                          "^[ ]*" ""
                          (buffer-substring-no-properties (point-min) (point-max))))
                       (concat "* Test header\n:PROPERTIES:\n:CREATED:  "
-                              (format-time-string (org-journal-created-property-format))
+                              (format-time-string org-journal-created-property-timestamp-format)
                               "\n:END:\n** TODO First\n** TODO Second\n"))))))
 
 (ert-deftest org-journal-carryover-keep-parents-test ()

--- a/org-journal-test.el
+++ b/org-journal-test.el
@@ -1,4 +1,4 @@
-;; org-journal-test.el --- Test file for org-journal
+;; org-journal-test.el --- Test file for org-journal -*- lexical-binding: t; -*-
 ;;
 ;; Author: Christian Schwarzgruber (c.schwarzgruber.cs@gmail.com)
 ;;
@@ -44,8 +44,7 @@
           (org-agenda-inhibit-startup t)
           (org-journal-time-format "%R")
           (org-journal-file-header "")
-          (org-journal-created-property-format-type 'ymd)
-          (new-entry (concat "** " (format-time-string org-journal-time-format))))
+          (org-journal-created-property-format-type 'ymd))
      (org-journal-dir-test-setup)
      ,@body))
 
@@ -133,7 +132,8 @@
 (ert-deftest org-journal-carryover-keep-parents-test ()
   "Org journal new entry test for daily files."
   (org-journal-test-macro
-   (let ((buffer "20181231"))
+   (let ((buffer "20181231")
+         (new-entry (concat "** " (format-time-string org-journal-time-format))))
      (with-temp-buffer
        (insert "* Wednesday, 01/02/19\n")
        (insert "** a\n")

--- a/org-journal-test.el
+++ b/org-journal-test.el
@@ -30,6 +30,7 @@
           (comment-start-skip "^\\s-*#\\(?: \\|$\\)")
           (org-journal-file-pattern (org-journal-file-pattern-test))
           (auto-mode-alist `(,(cons org-journal-file-pattern 'org-journal-mode) ,@auto-mode-alist))
+          (org-journal-cache-file (expand-file-name  "org-journal.cache" org-journal-dir-test))
           (org-journal-file-type 'daily)
           (org-journal-carryover-items "TODO=\"TODO\"")
           (org-journal-enable-cache nil)
@@ -108,7 +109,6 @@
        (write-file (expand-file-name buffer org-journal-dir-test))
        (kill-buffer buffer))
      (find-file (expand-file-name buffer org-journal-dir-test))
-     ;; (message "%333" format-args)
      (should (not (stringp (org-journal-read-or-display-entry (encode-time 0 0 0 1 1 2019)))))
      (kill-buffer buffer)
      (should (not (stringp (org-journal-read-or-display-entry (encode-time 0 0 0 2 1 2019)))))
@@ -167,6 +167,7 @@
   (org-journal-test-macro
    (let ((buffer "20181231")
          (org-journal-carryover-delete-empty-journal 'always))
+     ;; Test that journal file gets dumped, after carryover
      (with-temp-buffer
        (insert "* Wednesday, 01/02/19\n")
        (org-set-property "CREATED" "20190102")

--- a/org-journal.el
+++ b/org-journal.el
@@ -482,18 +482,20 @@ Returns the last value from BODY. If the buffer didn't exist before it will be d
   (if (org-journal-daily-p)
       (message "Nothing to do, org-journal-file-type is 'daily")
     (dolist (file (org-journal-list-files))
-      (let* ((buffer (get-buffer (file-name-nondirectory file)))
+      (let* ((inhibit-read-only)
+             (buffer (get-buffer (file-name-nondirectory file)))
              (buffer-modefied (when buffer (buffer-modified-p buffer))))
         (with-current-buffer (if buffer buffer (find-file-noselect file))
           (goto-char (point-min))
-          (dolist (date (reverse (let ((org-journal-created-property-timestamp-format old-format))
-                                   (org-journal-file->calendar-dates file))))
-            (unless (let ((org-journal-created-property-timestamp-format old-format))
-                      (org-journal-search-forward-created date nil t))
-              (error "Did not find journal entry in file (%s), date was (%s) " file date))
-            (org-set-property "CREATED" (format-time-string
-                                         org-journal-created-property-timestamp-format
-                                         (org-journal-calendar-date->time date))))
+          (ignore-errors
+            (dolist (date (reverse (let ((org-journal-created-property-timestamp-format old-format))
+                                     (org-journal-file->calendar-dates file))))
+              (unless (let ((org-journal-created-property-timestamp-format old-format))
+                        (org-journal-search-forward-created date nil t))
+                (error "Did not find journal entry in file (%s), date was (%s) " file date))
+              (org-set-property "CREATED" (format-time-string
+                                           org-journal-created-property-timestamp-format
+                                           (org-journal-calendar-date->time date)))))
           (unless buffer-modefied (save-buffer))
           (unless buffer (kill-buffer)))))))
 

--- a/org-journal.el
+++ b/org-journal.el
@@ -484,7 +484,7 @@ DATE should be a calendar date list (MONTH DAY YEAR)."
   "Convert CREATED property timestamps to `org-journal-created-property-format'."
   (interactive)
   (if (org-journal-daily-p)
-      (message "Nothing to do, org-journal file type is daily")
+      (message "Nothing to do, org-journal-file-type is 'daily")
     (dolist (file (org-journal-list-files))
       (let* ((buffer (get-buffer (file-name-nondirectory file)))
              (buffer-modefied (when buffer (buffer-modified-p buffer))))
@@ -497,9 +497,8 @@ DATE should be a calendar date list (MONTH DAY YEAR)."
                               (format-time-string
                                (org-journal-created-property-format)
                                (encode-time 0 0 0 (cadr date) (car date) (nth 2 date)))))
-          (message "current-buffer=%s" (current-buffer))
-          (unless buffer-modefied
-            (save-buffer)))))))
+          (unless buffer-modefied (save-buffer))
+          (unless buffer (kill-buffer)))))))
 
 (defun org-journal-convert-time-to-file-type-time (&optional time)
   "Converts TIME to the file type format date.

--- a/org-journal.el
+++ b/org-journal.el
@@ -620,6 +620,7 @@ hook is run."
       (unless (string= entry-path (buffer-file-name))
         (funcall org-journal-find-file entry-path))
 
+      ;; Insert org-journal-file-header
       (if (and (or (functionp org-journal-file-header)
                    (and (stringp org-journal-file-header)
                         (not (string-empty-p org-journal-file-header))))
@@ -673,7 +674,7 @@ hook is run."
               (org-set-tags org-crypt-tag-matcher)))))
       (org-journal-decrypt)
 
-      ;; move TODOs from previous day here
+      ;; Move TODOs from previous day to new entry
       (when (and org-journal-carryover-items
                  (not (string-blank-p org-journal-carryover-items))
                  (string= entry-path (org-journal-get-entry-path (current-time))))
@@ -683,7 +684,7 @@ hook is run."
           (outline-end-of-subtree)
         (goto-char (point-max)))
 
-      ;; insert the header of the entry
+      ;; Insert the header of the entry
       (when should-add-entry-p
         (unless (eq (current-column) 0) (insert "\n"))
         (let* ((day-discrepancy (- (time-to-days (current-time)) (time-to-days time)))
@@ -1198,9 +1199,6 @@ it into a list of calendar date elements."
                 (calendar-cursor-to-date t event))))
     (org-journal-read-or-display-entry time t)))
 
-;; silence compiler warning.
-(defvar view-exit-action)
-
 (defun org-journal-finalize-view ()
   "Finalize visability of entry."
   (org-journal-decrypt)
@@ -1221,7 +1219,7 @@ is nil or avoid switching when NOSELECT is non-nil."
          buf point)
     (if (and (when (file-exists-p org-journal-file)
                (setq buf (find-file-noselect org-journal-file)))
-             ;; If daily continue than clause of if condition
+             ;; If daily continue with than clause of if condition
              (or (org-journal-daily-p)
                  ;; Search for journal entry
                  (with-current-buffer buf


### PR DESCRIPTION
From new on inactive timestamp will be used for the created property.
The old style is still supported and will not be converted.