### PR TITLE
Add org-journal-after-header-create-hook

### DIFF
--- a/README.org
+++ b/README.org
@@ -335,7 +335,7 @@ With this done, you can export your agenda, including your scheduled entries, wi
 *** Journal Capture Template
 
 You can configure a capture template in order to integrate =org-journal= with =org-capture=,
-as in the following example:
+as in the following example for a daily journal:
 
 #+BEGIN_EXAMPLE emacs-lisp
   (defun org-journal-find-location ()
@@ -412,6 +412,10 @@ Old entries are opened in =view-mode=, which has convenient key bindings for bro
 
 Yes, you can write a custom function and assign it =org-journal-date-format=.
 
+*** Can I do more powerful things on a newly created journal entry?
+
+Yes, there are two hooks that are run when a journal entry is created.
+Each (=org-journal-new-entry=) will call =org-journal-after-entry-create-hook=, and =org-journal-after-header-create-hook= is called each time the date (the parent headline of each entry) is generated.
 
 ** Convenient =org-journal= Snippet Extensions
 

--- a/org-journal.el
+++ b/org-journal.el
@@ -390,6 +390,11 @@ if you have existing journal entries."
 (defvar org-journal-after-entry-create-hook nil
   "Hook called after journal entry creation.")
 
+(defvar org-journal-after-header-create-hook nil
+  "Hook called after journal header creation.
+The header is the string described by `org-journal-date-format'.
+This runs once per date, before `org-journal-after-entry-create-hook'.")
+
 (defvar org-journal-search-buffer "*Org-journal search*")
 
 
@@ -668,7 +673,8 @@ hook is run."
                                org-journal-created-property-timestamp-format time)))
           (when org-journal-enable-encryption
             (unless (member org-crypt-tag-matcher (org-get-tags))
-              (org-set-tags org-crypt-tag-matcher)))))
+              (org-set-tags org-crypt-tag-matcher)))
+          (run-hooks 'org-journal-after-header-create-hook)))
       (org-journal-decrypt)
 
       ;; Move TODOs from previous day to new entry


### PR DESCRIPTION
Add a hook that runs after the top-level date entry is created. I wanted a hook here to better add properties to the top-level drawer, e.g. a TIMEZONE property like
```
(add-hook 'org-journal-after-header-create-hook
                 (lambda ()
                   (org-set-property "TIMEZONE" (format-time-string "%Z"))))
```
This could be done with the existing after-entry-create-hook, but aside from being less efficient, the entry hook doesn't run if a journal entry is added through org-capture, like in the example given in the README, without further abuse.  Additionally there are likely other things that are best done only once per date.