### PR TITLE
Use magic-mode-alist instead auto-mode-alist to determine the mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -159,7 +159,6 @@ entries do =M-x calendar=. Bindings available in the =calendar-mode=:
 ** Setup and customization
 
 The following variables can be customized through =M-x customize=, or configured programmatically in your =.init.el=.
-When configuring manually, the use of =customize-set-variable= is advised over =setq=, since =org-journal= has customization hooks that update auxiliary variables which might not be picked up if set via =setq=.
 
 See below for an example.
 
@@ -167,8 +166,7 @@ See below for an example.
 
 Customization options related to journal directory and files:
 
-- =org-journal-dir= - the journal path. Tweaking this variable will also update
-  =auto-mode-alist= to ensure journal files are opened in =org-journal-mode=.
+- =org-journal-dir= - the journal path.
 
 - =org-journal-file-format= - format string for journal file names (may contain directories relative to =org-journal-dir=).
 
@@ -227,8 +225,8 @@ Customization options related to the journal file contents:
 A very basic example of customization.
 
 #+BEGIN_EXAMPLE emacs-lisp
-(customize-set-variable 'org-journal-dir "~/org/journal/")
-(customize-set-variable 'org-journal-date-format "%A, %d %B %Y")
+(setq org-journal-dir "~/org/journal/")
+(setq org-journal-date-format "%A, %d %B %Y")
 (require 'org-journal)
 #+END_EXAMPLE
 
@@ -238,9 +236,9 @@ For users of =use-package=, this setup could look like the following:
 (use-package org-journal
   :ensure t
   :defer t
-  :custom
-  (org-journal-dir "~/org/journal/")
-  (org-journal-date-format "%A, %d %B %Y"))
+  :config
+  (setq org-journal-dir "~/org/journal/"
+        org-journal-date-format "%A, %d %B %Y"))
 #+END_EXAMPLE
 
 ** Advanced Usage

--- a/org-journal-test.el
+++ b/org-journal-test.el
@@ -20,16 +20,10 @@
     (delete-file org-journal-cache-file))
   (make-directory org-journal-dir-test))
 
-(defun org-journal-file-pattern-test ()
-  (org-journal-dir-and-format->regex
-   org-journal-dir org-journal-file-format))
-
 (defmacro org-journal-test-macro (&rest body)
   "Wrapp a `org-journal' -- `ert'-test with default values."
   `(let* ((org-journal-dir org-journal-dir-test)
           (comment-start-skip "^\\s-*#\\(?: \\|$\\)")
-          (org-journal-file-pattern (org-journal-file-pattern-test))
-          (auto-mode-alist `(,(cons org-journal-file-pattern 'org-journal-mode) ,@auto-mode-alist))
           (org-journal-cache-file (expand-file-name  "org-journal.cache" org-journal-dir-test))
           (org-journal-file-type 'daily)
           (org-journal-date-format "Test header")


### PR DESCRIPTION
In `magic-mode-alist` we can use a function to determine if the
file is a journal file, and return `t` if it is one, otherwise `nil`.
That way we don't need any `:custom` keyword in the defcustom's, and hence,
org-journal is less complex to setup and use.

Takes away the complexity from the user, and moves it to the developer.


@bastibe Please have look at this.