### PR TITLE
Update docstring for org-journal-date-prefix

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -177,13 +177,14 @@ appropriate way to format days in your language."
   :type 'string)
 
 (defcustom org-journal-date-prefix "* "
-  "String that is put before every date at the top of a journal file.
+  "Prefix for `org-journal-date-format'.
 
-By default, this is a org-mode heading. Another good idea would be
-\"#+TITLE: \" for org titles.
-
-Setting `org-journal-date-prefix' to something other than \"* \"
-for weekly/monthly/yearly journal files won't work correctly."
+The default prefix creates an `org-mode' heading.  This default
+should not be changed for weekly, monthly or yearly journal
+files.  An alternative for daily journal files could be
+\"#+title: \" creating a title rather than a heading.  To create
+a \"#+title: \" for weekly, monthly or yearly (but also daily)
+journal files, customize `org-journal-file-header' instead."
   :type 'string)
 
 (defcustom org-journal-time-format "%R "


### PR DESCRIPTION
Fixes issue #249.

I've left a blank line between the first line and the following paragraph in keeping with the style of the other docstrings though I don't think it is strictly necessary. I've used two spaces at the end of a sentence as I believe that is the standard convention though I notice other docstrings do not but otherwise `flycheck` issues a warning. Please let me know if you prefer to use a single space. Perhaps, your preferred convention could be defined in a `.dir-locals.el` file. 