### PR TITLE
Update use-package example to use :custom

### DIFF
--- a/README.org
+++ b/README.org
@@ -236,9 +236,9 @@ For users of =use-package=, this setup could look like the following:
 (use-package org-journal
   :ensure t
   :defer t
-  :config
-  (setq org-journal-dir "~/org/journal/"
-        org-journal-date-format "%A, %d %B %Y"))
+  :custom
+  (org-journal-dir "~/org/journal/")
+  (org-journal-date-format "%A, %d %B %Y"))
 #+END_EXAMPLE
 
 ** Advanced Usage


### PR DESCRIPTION
The function that calculates the directory regex needs to run with `org-journal-dir` is customized. When I had my configuration under `:config` with `setq` this didn't happen. Moving to using `use-package`'s `:custom` feature works.