### PR TITLE
Remove harcoded key-bindings and move them to user-config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -127,3 +127,6 @@
   - Lot of general code improvements and bug fixes
   - Documentation update (Thank you, Doolio)
   - Support %b/%B in org-journal-file-format (Thank you, Jinhee Baek)
+
+## TBD
+  - Move default key-bindings from codebase to user-config

--- a/README.org
+++ b/README.org
@@ -422,7 +422,7 @@ When working in an org-journal buffer the following org-mode key bindings are ov
 - =C-c C-b= (=org-backward-heading-same-level=) with =org-journal-open-previous-entry=
 - =C-c C-j= (=org-goto=) with =org-journal-new-entry=
 
-To workaround this, you can use user bindings of the form =C-c ?=, where =?= can be any letter, to call the org-journal functions. This allows you to have a set of keybindings that work the same in org-mode and org-journal buffers. However, this is Emacs, and if you don't like a key binding, change it!
+To workaround this, you can use user bindings of the form =C-c ?=, where =?= can be any letter, to call the org-journal functions. This allows you to have a set of keybindings that work the same in org-mode and org-journal buffers. However, this is Emacs, and if you don't like a key binding, change it in your configuration!
 
 *** Opening journal entries from the calendar are not editable
 

--- a/README.org
+++ b/README.org
@@ -230,6 +230,10 @@ A very basic example of customization.
 (setq org-journal-dir "~/org/journal/")
 (setq org-journal-date-format "%A, %d %B %Y")
 (require 'org-journal)
+(define-key org-journal-mode-map (kbd "C-c C-f") 'org-journal-next-entry)
+(define-key org-journal-mode-map (kbd "C-c C-b") 'org-journal-previous-entry)
+(define-key org-journal-mode-map (kbd "C-c C-j") 'org-journal-new-entry)
+(define-key org-journal-mode-map (kbd "C-c C-s") 'org-journal-search)
 #+END_EXAMPLE
 
 For users of =use-package=, this setup could look like the following:
@@ -238,6 +242,11 @@ For users of =use-package=, this setup could look like the following:
 (use-package org-journal
   :ensure t
   :defer t
+  :bind (:map org-journal-mode-map
+         ("C-c C-f" . org-journal-next-entry)
+         ("C-c C-b" . org-journal-previous-entry)
+         ("C-c C-j" . org-journal-new-entry)
+         ("C-c C-s" . org-journal-search))
   :config
   (setq org-journal-dir "~/org/journal/"
         org-journal-date-format "%A, %d %B %Y"))

--- a/README.org
+++ b/README.org
@@ -227,9 +227,9 @@ Customization options related to the journal file contents:
 A very basic example of customization.
 
 #+BEGIN_EXAMPLE emacs-lisp
+(require 'org-journal)
 (setq org-journal-dir "~/org/journal/")
 (setq org-journal-date-format "%A, %d %B %Y")
-(require 'org-journal)
 (define-key org-journal-mode-map (kbd "C-c C-f") 'org-journal-next-entry)
 (define-key org-journal-mode-map (kbd "C-c C-b") 'org-journal-previous-entry)
 (define-key org-journal-mode-map (kbd "C-c C-j") 'org-journal-new-entry)

--- a/org-journal.el
+++ b/org-journal.el
@@ -373,11 +373,6 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
 (define-obsolete-function-alias 'org-journal-open-previous-entry 'org-journal-previous-entry)
 
 ;; Key bindings
-(define-key org-journal-mode-map (kbd "C-c C-f") 'org-journal-next-entry)
-(define-key org-journal-mode-map (kbd "C-c C-b") 'org-journal-previous-entry)
-(define-key org-journal-mode-map (kbd "C-c C-j") 'org-journal-new-entry)
-(define-key org-journal-mode-map (kbd "C-c C-s") 'org-journal-search)
-
 (eval-after-load "calendar"
   '(progn
     (define-key calendar-mode-map (kbd "j m") 'org-journal-mark-entries)


### PR DESCRIPTION
Closes #255.

I'm not a big fan of hardcoding key-bindings for minor-modes that are magically loaded, especially when they override existing ones.  It makes it complicated for users to rebind or unbind them without first emptying the keymap.

I'd like to move those key-bindings from codebase to user-config.  This is something that we've done with [Org-roam](https://github.com/org-roam/org-roam#installation), and we haven't encountered any problem with it.

I took the liberty to update the `CHANGELOG` as well.

Thank you for `org-journal`. :)