### PR TITLE
Use org-store-new-agenda-file-list to manipulate org-agenda-files

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -1438,8 +1438,8 @@ and cleans out past org-journal files."
              (org-journal-search-build-file-list
               (org-journal-calendar-date->time beg)
               (org-journal-calendar-date->time end)))))
-      (setq org-agenda-files (append not-org-journal-agenda-files
-                                     org-journal-agenda-files)))))
+      (org-store-new-agenda-file-list (append not-org-journal-agenda-files
+					      org-journal-agenda-files)))))
 
 (defvar org-journal-schedule-buffer-name "*Org-journal schedule*")
 


### PR DESCRIPTION
This does the right thing when org-agenda-files is a string containing a filename rather than a list. In this case Org updates the file with the org-agenda-files, one line at a time.

This fixes #280.