### PR TITLE
Added '%V' shortcode to allow week numbers in org journal files

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -161,12 +161,13 @@ MUST at least include `%Y' and `%m', and at least `%Y' when
 
 Currently supported placeholders are:
 
-%Y is the year.
-%m is the numeric month.
-%d is the day of the month, zero-padded.
+%Y is the year as decimal number, including the century.
+%m is the month as a decimal number (range 01 to 12).
+%d is the day as a decimal number (range 01 to 31).
+%V is the ISO 8601 week number as a decimal number (range 01 to 53).
 %a is the locale’s abbreviated name of the day of week, %A the full name.
 %b is the locale's abbreviated name of the month, %B the full name.
-%F is the ISO 8601 date format (like \"%+4Y-%m-%d\")."
+%F is the ISO 8601 date format (equivalent to \"%Y-%m-%d\")."
   :type 'string)
 
 (defcustom org-journal-date-format "%A, %x"
@@ -329,12 +330,13 @@ month and day.
 
 Currently supported placeholders are:
 
-%Y is the year.
-%m is the numeric month.
-%d is the day of the month, zero-padded.
+%Y is the year as decimal number, including the century.
+%m is the month as a decimal number (range 01 to 12).
+%d is the day as a decimal number (range 01 to 31).
+%V is the ISO 8601 week number as a decimal number (range 01 to 53).
 %a is the locale’s abbreviated name of the day of week, %A the full name.
 %b is the locale's abbreviated name of the month, %B the full name.
-%F is the ISO 8601 date format (like \"%+4Y-%m-%d\").
+%F is the ISO 8601 date format (equivalent to \"%Y-%m-%d\").
 
 You must call `org-journal-convert-created-property-timestamps' afterwards,
 if you have existing journal entries."
@@ -456,7 +458,8 @@ Returns the last value from BODY. If the buffer didn't exist before it will be d
   '(("%[aAbB]" . "\\\\(?4:[a-zA-Z]\\\\{3,\\\\}\\\\)")
     ("%d" . "\\\\(?3:[0-9]\\\\{2\\\\}\\\\)")
     ("%m" . "\\\\(?2:[0-9]\\\\{2\\\\}\\\\)")
-    ("%Y" . "\\\\(?1:[0-9]\\\\{4\\\\}\\\\)")))
+    ("%Y" . "\\\\(?1:[0-9]\\\\{4\\\\}\\\\)")
+    ("%V" . "[0-9]\\\\{2\\\\}")))
 
 (defun org-journal-format->regex (format)
   (setq format (replace-regexp-in-string "%F" "%Y-%m-%d" format))


### PR DESCRIPTION
# Description
This small change just adds the **%V short code for ISO 8601 week number** to the format-rx-alist variable.
While adapting the docstrings for the new variable I decided to harmonize them a bit as well.

# Motivation and Context
I was missing the week number as a valid file name expansion. My org-journal-file-format variable has the value   
**W%V_%Y-%m-%d.org** which translates to **W33_2020-08-14.org** as an example.

This _W[0-9]{2}_ file prefix makes it not only easy to filter for specific weeks, it matches the **org mode Week-agenda** view. Below are my org mode settings where I pull the daily org journal files into the org-agenda-files and generate an ongoing clockreport.

The function org-journal-enable-agenda-integration erases past org journal entries so it's not an option for the above use case.

## Relevant org mode settings
```
(setq org-directory "~/Dropbox/org/"
      org-agenda-files
          (directory-files org-directory t (concat "^W" (format-time-string "%V")))    
      org-agenda-start-with-clockreport-mode t
      org-agenda-clockreport-parameter-plist '(:link t :maxlevel 2 :fileskip0 t :compact t :narrow 80 :tags t)
```
