### PR TITLE
adding daily files for testing

### DIFF
--- a/tests/journals/daily/2020-10-22.org
+++ b/tests/journals/daily/2020-10-22.org
@@ -1,0 +1,7 @@
+#+TITLE: 2020-10-22 (Thursday)
+
+* TODO test 1
+ <2020-10-22>
+
+* TODO test 2
+ <2020-10-22>

--- a/tests/journals/daily/2020-10-23.org
+++ b/tests/journals/daily/2020-10-23.org
@@ -1,0 +1,7 @@
+#+TITLE: 2020-10-23 (Friday)
+
+* TODO test 1
+ <2020-10-23 Fri>
+
+* TODO test 2
+ <2020-10-23 Fri>


### PR DESCRIPTION
These are two daily files according to my configuration. I expect the most recent one to be created when carrying items over from the oldest one. My org-journal configuration is:
```emacs-lisp
(use-package! org-journal
  :config
  (map!
   (:leader
    (:n "d o j" 'org-journal-new-entry)))
  :custom
  (org-journal-dir deft-directory)
  (org-journal-cache-file "~/.emacs.d/.local/org-journal.cache")
  (org-journal-date-prefix "#+TITLE: ")
  (org-journal-time-prefix "* ")
  (org-journal-file-format "%Y-%m-%d.org")
  (org-journal-date-format "%Y-%m-%d (%A)"))
(setq org-journal-enable-agenda-integration t)
```