### PR TITLE
Enable to costomize the way to handle the old carryover entries

### DIFF
--- a/README.org
+++ b/README.org
@@ -295,14 +295,13 @@ Default is to remove all of them. You can change this behavior by
 assigning a custom fuction to the variable.
 Your function has to take one argument, which is a list of old carryover entries. The list is in form of ((START_POINT (END_POINT . "TEXT")) ... (START_POINT (END_POINT . "TEXT"))); and in ascending order of START_POINT.
  
-The example below puts a tag on the old carryover entries intead of
-removing them.
+For example, you can choose putting a tag on the old carryover entries intead of removing them:
 
 #+begin_src elisp
 (defun my-old-carryover (old_carryover)
   (save-excursion
     (let ((matcher (cdr (org-make-tags-matcher org-journal-carryover-items))))
-      (dolist (entry old_carryover)
+      (dolist (entry (reverse old_carryover))
         (save-restriction
           (narrow-to-region (car entry) (cadr entry)) 
           (goto-char (point-min))

--- a/README.org
+++ b/README.org
@@ -282,14 +282,36 @@ Search is also available through the Emacs Calendar as described in "Basic Usage
 *** Carry Over
 
 By default, =org-journal= will try to /carry over/ previous day TODO-marked
-items whenever a new journal file is created. The older journal entry will be
-/moved/ (i.e., deleted and reinserted) to the current day's file.
+items whenever a new journal file is created. The older journal entry will be inserted to the current day's file.
 
 This feature is controlled through the =org-journal-carryover-items=
 variable. To disable this feature set =org-journal-carryover-items= to an
 empty string =""=. Any [[http://orgmode.org/manual/Matching-tags-and-properties.html][agenda tags view match string]], tags, properties, and
 todo states are allowed. By default this is ~TODO=”TODO”~. Which will
 match TODO items.
+
+The old carryover items in the previos day's journal are processed by the function assigned to =org-journal-handle-old-carryover= variable. 
+Default is to remove all of them. You can change this behavior by
+assigning a custom fuction to the variable.
+Your function has to take one argument, which is a list of old carryover entries. The list is in form of ((START_POINT (END_POINT . "TEXT")) ... (START_POINT (END_POINT . "TEXT"))); and in ascending order of START_POINT.
+ 
+The example below puts a tag on the old carryover entries intead of
+removing them.
+
+#+begin_src elisp
+(defun my-old-carryover (old_carryover)
+  (save-excursion
+    (let ((matcher (cdr (org-make-tags-matcher org-journal-carryover-items))))
+      (dolist (entry old_carryover)
+        (save-restriction
+          (narrow-to-region (car entry) (cadr entry)) 
+          (goto-char (point-min))
+          (org-scan-tags '(lambda ()
+                            (org-set-tags ":carried:"))
+                         matcher org--matcher-tags-todo-only))))))
+
+(setq org-journal-handle-old-carryover 'my-old-carryover)
+#+end_src
 
 You can also skip carry over of [[https://orgmode.org/manual/Drawers.html][Drawers]] through the
 =org-journal-skip-carryover-drawers= variable. This is specifically

--- a/org-journal.el
+++ b/org-journal.el
@@ -265,11 +265,12 @@ here will be wiped completely, when the item gets carried over."
   :type 'list)
 
 (defcustom org-journal-handle-old-carryover 'org-journal--delete-old-carryover
-  "The function to handle the carried-over entries in the previous journal.
+  "The function to handle the carryover entries in the previous journal.
 
-This function takes one argument, which is a list of the carried-over entries
+This function takes one argument, which is a list of the carryover entries
 in the journal of previous day.
-The list is in form of ((START_POINT (END_POINT . \"TEXT\")) ... (START_POINT (END_POINT . \"TEXT\"))); and in ascending order of START_POINT.
+The list is in form of ((START_POINT (END_POINT . \"TEXT\")) ... (START_POINT (END_POINT . \"TEXT\"))); 
+and in ascending order of START_POINT.
 
 Default is the function `org-journal--delete-old-carryover' to delete them all."
   :type 'function)
@@ -815,8 +816,8 @@ items, and delete or not delete the empty entry/file based on
           (kill-region (point) (progn (outline-end-of-subtree) (point)))
           (save-buffer))))))
 
-(defun org-journal--delete-old-carryover (old_entries &rest _args)
-  "Delete all carried-over entries from previous buffer.
+(defun org-journal--delete-old-carryover (old_entries)
+  "Delete all carryover entries from the previous day's journal.
 
 If the parent heading has no more content, delete it as well."
   (mapc (lambda (x)
@@ -830,7 +831,7 @@ If the parent heading has no more content, delete it as well."
   "Carryover items.
 
 Will insert `entries', and run `org-journal-handle-old-carryover' function
-to process the carried-over entries in `prev-buffer'."
+to process the carryover entries in `prev-buffer'."
   (when entries
     (if (org-journal--org-heading-p)
         (progn
@@ -868,7 +869,7 @@ to process the carried-over entries in `prev-buffer'."
 
     (outline-end-of-subtree)
 
-    ;; Process carried-over entries in the previous day
+    ;; Process carryover entries in the previous day's journal
     (with-current-buffer prev-buffer
       (funcall org-journal-handle-old-carryover entries))))
 


### PR DESCRIPTION
**Feature Request**
  When carryover occurs, old carryover entries in the previous day's journal are deleted. No other options.
  It would be nice if users can choose what they do with old carryover entries.

**Solution I would like**
   To make it enable for users to choose a function to handle the old entries instead of removing them all.
   The function could default to deleting old entries.