### PR TITLE
Add missing third arg to `define-obsolete-function-alias`

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -397,9 +397,9 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
   (run-mode-hooks))
 
 ;;;###autoload
-(define-obsolete-function-alias 'org-journal-open-next-entry 'org-journal-next-entry)
+(define-obsolete-function-alias 'org-journal-open-next-entry 'org-journal-next-entry "2.1.0")
 ;;;###autoload
-(define-obsolete-function-alias 'org-journal-open-previous-entry 'org-journal-previous-entry)
+(define-obsolete-function-alias 'org-journal-open-previous-entry 'org-journal-previous-entry "2.1.0")
 
 ;; Key bindings
 (when (and (stringp org-journal-prefix-key) (not (string-empty-p org-journal-prefix-key)))


### PR DESCRIPTION
These aliases were defined in 3b7b9e69d96933992b8174f48d3893412ceca54a,
before the 2.1.0 tag.