### PR TITLE
Add new to front

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -686,6 +686,7 @@ hook is run."
                                (lambda (a b)
                                  (org-journal--calendar-date-compare b a)))))
               (setq date (list (nth 4 date) (nth 3 date) (nth 5 date)))
+              (setq first-date (car dates))
               (while dates
                 (when (org-journal--calendar-date-compare (car dates) date)
                   (org-journal--search-forward-created (car dates))
@@ -693,7 +694,15 @@ hook is run."
                   (insert "\n")
                   (setq match t
                         dates nil))
-                (setq dates (cdr dates)))))
+                (setq dates (cdr dates)))
+              ; All dates in file are older than this new date
+              ; Insert before first
+              (when (and first-date (not match))
+                  (org-journal--search-forward-created first-date)
+                  (forward-line -2)
+                  (insert "\n")
+                  (forward-line -1)
+                  (setq match t))))
           ;; True if entry must be inserted at the end of the journal file.
           (unless match
             (goto-char (point-max))


### PR DESCRIPTION
When adding a new daily entry to an existing file we try to insert the new entry in the correct place. Current implementation gathers all existing entries, sorts them in descending order then searches for first one that is "earlier than new one" and inserts the new entry directly after that.

In case when all entries are "younger" than the new one (i.e. are in future) such entry is not found and new entry is inserted at the end of the file which is incorrect. The following example demonstrates this:

```
#startup: content
#category: journal
* 2021-01-20, Wednesday
:PROPERTIES:
:CREATED:  20210121
:END:
** TODO Something
SCHEDULED: <2021-01-20 Wed>
```

Weekly journal, starts on Monday. When creating a new entry on Monday 18th or Tuesday 19th it will be placed at the end of file. My change fixes that and inserts the new entry between header and the Wednesday entry.