### PR TITLE
Create insert journal headline at point

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -632,7 +632,7 @@ This allows the use of `org-journal-tag-alist' and
       (when (re-search-backward "^#\\+" nil t)
         (org-ctrl-c-ctrl-c)))))
 
-(defun org-journal--insert-entry-header (time)
+(defun org-journal--insert-entry-header (time &optional insert-at-point)
   "Create new journal entry if there isn't one."
   (let ((entry-header
          (if (functionp org-journal-date-format)
@@ -641,7 +641,8 @@ This allows the use of `org-journal-tag-alist' and
              (user-error "org-journal-date-format is empty, this won't work"))
            (concat org-journal-date-prefix
                    (format-time-string org-journal-date-format time)))))
-    (goto-char (point-min))
+    (unless insert-at-point
+      (goto-char (point-min)))
     (unless (if (org-journal--daily-p)
                 (or (search-forward entry-header nil t) (and (goto-char (point-max)) nil))
               (cl-loop
@@ -689,6 +690,11 @@ This allows the use of `org-journal-tag-alist' and
         (unless (member org-crypt-tag-matcher (org-get-tags))
           (org-set-tags org-crypt-tag-matcher)))
       (run-hooks 'org-journal-after-header-create-hook))))
+
+(defun org-journal-insert-header-at-point ()
+  "Create journal style headline at point."
+  (interactive)
+  (org-journal--insert-entry-header (current-time) t))
 
 (defun org-journal--insert-entry (time org-extend-today-until-active-p)
   "Insert a new entry."

--- a/org-journal.el
+++ b/org-journal.el
@@ -690,7 +690,7 @@ This allows the use of `org-journal-tag-alist' and
         (unless (member org-crypt-tag-matcher (org-get-tags))
           (org-set-tags org-crypt-tag-matcher)))
       (run-hooks 'org-journal-after-header-create-hook))))
-
+;;;###autoload
 (defun org-journal-insert-header-at-point ()
   "Create journal style headline at point."
   (interactive)
@@ -780,6 +780,7 @@ hook is run."
     (when should-add-entry-p
       (outline-show-entry))))
 
+;;;###autoload
 (defun org-journal-new-entry-at-point (prefix &optional time todo)
   "Insert a journal style entry at current cursor location."
   (interactive "P")
@@ -1081,6 +1082,7 @@ With non-nil prefix argument create a regular entry instead of a TODO entry."
       (org-insert-time-stamp time t)
       (org-cycle))))
 
+;;;###autoload
 (defun org-journal-new-scheduled-entry-at-point (prefix &optional scheduled-time)
   "Insert a journal style scheduled entry at current cursor location."
   (interactive "P")

--- a/org-journal.el
+++ b/org-journal.el
@@ -696,7 +696,7 @@ This allows the use of `org-journal-tag-alist' and
   (interactive)
   (org-journal--insert-entry-header (current-time) t))
 
-(defun org-journal--insert-entry (time org-extend-today-until-active-p)
+(defun org-journal--insert-entry (time org-extend-today-until-active-p &optional todo)
   "Insert a new entry."
   (unless (eq (current-column) 0) (insert "\n"))
   (let* ((day-discrepancy (- (time-to-days (current-time)) (time-to-days time)))
@@ -712,11 +712,11 @@ This allows the use of `org-journal-tag-alist' and
                          (format-time-string org-journal-time-format)))
                       ;; “time” is on some other day, use blank timestamp
                       (t ""))))
-    (insert org-journal-time-prefix timestamp))
+    (insert (concat org-journal-time-prefix (when todo "TODO ") timestamp)))
   (run-hooks 'org-journal-after-entry-create-hook))
 
 ;;;###autoload
-(defun org-journal-new-entry (prefix &optional time)
+(defun org-journal-new-entry (prefix &optional time todo)
   "Open today's journal file and start a new entry.
 
 With a PREFIX arg, open the today's file, create a heading if it doesn't exist yet,
@@ -770,7 +770,7 @@ hook is run."
       (goto-char (point-max)))
 
     (when should-add-entry-p
-      (org-journal--insert-entry time org-extend-today-until-active-p))
+      (org-journal--insert-entry time org-extend-today-until-active-p todo))
 
     (if (and org-journal-hide-entries-p (org-journal--time-entry-level))
         (outline-hide-sublevels (org-journal--time-entry-level))
@@ -1068,12 +1068,12 @@ With non-nil prefix argument create a regular entry instead of a TODO entry."
         org-journal-carryover-items)
     (when (time-less-p time (current-time))
       (user-error "Scheduled time needs to be in the future"))
-    (org-journal-new-entry nil time)
-    (unless prefix
-      (insert "TODO "))
+    (org-journal-new-entry nil time (not prefix))
     (save-excursion
       (insert "\n")
-      (org-insert-time-stamp time))))
+      (insert "SCHEDULED: ")
+      (org-insert-time-stamp time t)
+      (org-cycle))))
 
 ;;;###autoload
 (defun org-journal-reschedule-scheduled-entry (&optional time)


### PR DESCRIPTION
I have a project where I would like to use journal style headlines outside a journal file. This small adjustment enables the option to insert journal style headlines at point. I thought it might be useful sometimes for other user too. If you think the extra command is too "exclusive" to be added by default then it is no problem if you remove it. But then it would still be nice to keep the optional `insert-at-point` argument.