### PR TITLE
Add scheduled entry time of the day

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -1067,7 +1067,7 @@ With non-nil prefix argument create a regular entry instead of a TODO entry."
       (insert "TODO "))
     (save-excursion
       (insert "\n")
-      (org-insert-time-stamp time))))
+      (org-insert-time-stamp time t))))
 
 ;;;###autoload
 (defun org-journal-reschedule-scheduled-entry (&optional time)


### PR DESCRIPTION
Probably this `t` was forgotten here. This function asks for time-stamp format, For sure when users include a time of the day there, they would like to have it included in the timestamp.