### PR TITLE
Add a more robust set for `org-capture-templates` to README.org.

### DIFF
--- a/README.org
+++ b/README.org
@@ -373,35 +373,49 @@ You can configure a capture template in order to integrate =org-journal= with =o
 as in the following example for a daily journal:
 
 #+BEGIN_EXAMPLE emacs-lisp
-  (defun org-journal-find-location ()
-    ;; Open today's journal, but specify a non-nil prefix argument in order to
-    ;; inhibit inserting the heading; org-capture will insert the heading.
-    (org-journal-new-entry t)
-    (unless (eq org-journal-file-type 'daily)
-      (org-narrow-to-subtree))
-    (goto-char (point-max)))
-
-  (setq org-capture-templates '(("j" "Journal entry" plain (function org-journal-find-location)
-                                 "** %(format-time-string org-journal-time-format)%^{Title}\n%i%?"
-                                 :jump-to-captured t :immediate-finish t)))
+(cl-labels
+ ((org-journal-find-location ()
+  ;; Open today's journal, but specify a non-nil prefix argument in order to
+  ;; inhibit inserting the heading; org-capture will insert the heading.
+  (org-journal-new-entry t)
+  (unless (eq org-journal-file-type 'daily)
+    (org-narrow-to-subtree))
+    (goto-char (point-max))))
+ (use-package org-journal
+              :ensure t
+              :demand t
+              :after org
+              :config
+              (setf (alist-get "j" org-capture-templates nil nil #'string-equal)
+                 `("Journal entry"
+                   plain
+                   (function ,#'org-journal-find-location)
+                   "** %(format-time-string org-journal-time-format)%^{Title}\n%i%?"
+                   :jump-to-captured t
+                   :immediate-finish t))))
 #+END_EXAMPLE
 
 If you want to do the same to schedule a task for a future date, you can use the following:
 
 #+BEGIN_EXAMPLE emacs-lisp
-  (defvar org-journal--date-location-scheduled-time nil)
-
-  (defun org-journal-date-location (&optional scheduled-time)
+(defvar org-journal--date-location-scheduled-time nil)
+(cl-labels
+ ((org-journal-date-location (&optional scheduled-time)
     (let ((scheduled-time (or scheduled-time (org-read-date nil nil nil "Date:"))))
       (setq org-journal--date-location-scheduled-time scheduled-time)
       (org-journal-new-entry t (org-time-string-to-time scheduled-time))
       (unless (eq org-journal-file-type 'daily)
         (org-narrow-to-subtree))
-      (goto-char (point-max))))
-
-  (setq org-capture-templates '(("j" "Journal entry" plain (function org-journal-date-location)
+      (goto-char (point-max)))))
+ (use-package org-journal
+              :ensure t
+              :demand t
+              :after org
+              :config
+              (setf (alist-get "j" org-capture-templates nil nil #'string-equal)
+                 `(("Journal entry" plain (function ,#'org-journal-date-location)
                                  "** TODO %?\n <%(princ org-journal--date-location-scheduled-time)>\n"
-                                 :jump-to-captured t))
+                                 :jump-to-captured t)))))
 #+END_EXAMPLE
 
 *** Caching of journal dates


### PR DESCRIPTION
- Replace a straightforward setq with a smarter setf/alist-get.

This should fix #343 
