### PR TITLE
Remove key definition in the package loading.

### DIFF
--- a/README.org
+++ b/README.org
@@ -113,12 +113,15 @@ Then add =(require 'org-journal)= to your =.emacs=.
 
 ** Quickstart
 
-Doing =M-x org-journal-new-entry= (or =C-c C-j=) will immediately create a journal
-directory in the default path (customized using the =org-journal-dir= variable), open or
-create a file in =org-journal-mode=, and insert a template for a new journal entry.
+Doing =M-x org-journal-new-entry= will immediately create a journal
+directory in the default path (customized using the =org-journal-dir=
+variable), open or create a file in =org-journal-mode=, and insert a
+template for a new journal entry.
 
-The same command with a prefix argument (=C-u C-c C-j=) will do everything mentioned while
-skipping entry creation, which is useful for looking at the current journal file.
+The same command with a prefix argument (=C-u M-x
+org-journal-new-entry=) will do everything mentioned while skipping
+entry creation, which is useful for looking at the current journal
+file.
 
 ** Basic Usage
 

--- a/org-journal.el
+++ b/org-journal.el
@@ -423,8 +423,6 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
     (define-key calendar-mode-map (kbd "j s m") 'org-journal-search-calendar-month)
     (define-key calendar-mode-map (kbd "j s y") 'org-journal-search-calendar-year)))
 
-(global-set-key (kbd "C-c C-j") 'org-journal-new-entry)
-
 (defmacro org-journal--with-journal (file &rest body)
   "Opens JOURNAL-FILE in fundamental mode, or switches to the buffer which is visiting JOURNAL-FILE.
 

--- a/org-journal.el
+++ b/org-journal.el
@@ -30,8 +30,9 @@
 ;; different times. Any subsequent entries on the same day are written
 ;; in the same file, with their own timestamp. You can customize the
 ;; date and time formats (or remove them entirely). To start writing a
-;; journal entry, press "C-c C-j". You can also open the current day's
-;; entry without adding a new entry with "C-u C-c C-j".
+;; journal entry, "M-x org-journal-new-entry". You can also open the
+;; current day's entry without adding a new entry with "C-u M-x
+;; org-journal-new-entry".
 ;;
 ;; You can browse through existing journal entries on disk via the
 ;; calendar. All dates for which an entry is present are highlighted.
@@ -45,8 +46,8 @@
 ;; day. This is customizable through org-journal-carryover-items.
 ;;
 ;; Quick summary:
-;; To create a new journal entry for the current time and day: C-c C-j
-;; To open today's journal without creating a new entry: C-u C-c C-j
+;; To create a new journal entry for the current time and day: M-x org-journal-new-entry
+;; To open today's journal without creating a new entry: C-u M-x org-journal-new-entry
 ;; In calendar view: j m to mark entries in calendar
 ;;                   j r to view an entry in a new buffer
 ;;                   j d to view an entry but not switch to it
@@ -399,7 +400,8 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
 
 ;; Key bindings
 (when (and (stringp org-journal-prefix-key) (not (string-empty-p org-journal-prefix-key)))
-  (let ((command-table '(("f" . org-journal-next-entry)
+  (let ((command-table '(("j" . org-journal-new-entry)
+                         ("f" . org-journal-next-entry)
                          ("b" . org-journal-previous-entry)
                          ("j" . org-journal-new-entry)
                          ("s" . org-journal-search)))

--- a/org-journal.el
+++ b/org-journal.el
@@ -400,8 +400,7 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
 
 ;; Key bindings
 (when (and (stringp org-journal-prefix-key) (not (string-empty-p org-journal-prefix-key)))
-  (let ((command-table '(("j" . org-journal-new-entry)
-                         ("f" . org-journal-next-entry)
+  (let ((command-table '(("f" . org-journal-next-entry)
                          ("b" . org-journal-previous-entry)
                          ("j" . org-journal-new-entry)
                          ("s" . org-journal-search)))


### PR DESCRIPTION
Avoid modification of Emacs behavior on the package loading.

In order to follow [the coding convention](https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html), disable key definition in the package loading
