### PR TITLE
Document org-journal-hide-entries-p

### DIFF
--- a/README.org
+++ b/README.org
@@ -222,6 +222,10 @@ Customization options related to the journal file contents:
   (setq org-journal-file-header 'org-journal-file-header-func)
   #+END_EXAMPLE
 
+- =org-journal-hide-entries-p= - a boolean (defaults to =true=) that will
+  hide previous journal entries if true. Can be set to =nil= to show previous
+  entries.
+
 *** An example setup
 
 A very basic example of customization.


### PR DESCRIPTION
I was looking how not to hide previous entries when running `org-journal-new-entry`, could not find anything in the README but found this variable while reading the source code.

I think it would be valuable to have it in the documentation for people like me who want to see their previous entries when writing a new one.