### PR TITLE
Add NonGNU ELPA badge to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,4 @@
-[[https://travis-ci.org/bastibe/org-journal][file:https://travis-ci.org/bastibe/org-journal.svg?branch=master]] [[http://melpa.org/#/org-journal][file:http://melpa.org/packages/org-journal-badge.svg]] [[http://stable.melpa.org/#/org-journal][file:http://stable.melpa.org/packages/org-journal-badge.svg]] [[contributors][file:https://img.shields.io/github/contributors/bastibe/org-journal.svg]] [[license][file:https://img.shields.io/github/license/bastibe/org-journal.svg]]
+[[https://travis-ci.org/bastibe/org-journal][file:https://travis-ci.org/bastibe/org-journal.svg?branch=master]] [[https://elpa.nongnu.org/nongnu/org-journal.html][https://elpa.nongnu.org/nongnu/org-journal.svg]] [[http://melpa.org/#/org-journal][file:http://melpa.org/packages/org-journal-badge.svg]] [[http://stable.melpa.org/#/org-journal][file:http://stable.melpa.org/packages/org-journal-badge.svg]] [[contributors][file:https://img.shields.io/github/contributors/bastibe/org-journal.svg]] [[license][file:https://img.shields.io/github/license/bastibe/org-journal.svg]]
 
 #+CAPTION: The org-journal logo
 [[./org-journal.svg]]


### PR DESCRIPTION
This package has now been added to NonGNU ELPA!

This commit adds a NonGNU ELPA badge as it looks nice, and is occasionally useful.

Thanks!