### PR TITLE
Skip mark entries

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -403,11 +403,23 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
 
 (defvar org-journal--search-buffer "*Org-journal search*")
 
-
+(defvar org-journal-dont-mark-entries nil)
+
 ;;;###autoload
 (add-hook 'calendar-today-visible-hook 'org-journal-mark-entries)
 ;;;###autoload
 (add-hook 'calendar-today-invisible-hook 'org-journal-mark-entries)
+
+(defun org-journal--org-read-date (orig-fun &rest args)
+  "In the case where the calendar is opened to input a timestamp, don't mark entries."
+  (progn
+    (setq org-journal-dont-mark-entries t)
+    (unwind-protect
+        (apply orig-fun args)
+      (setq org-journal-dont-mark-entries nil))))
+
+;;;###autoload
+(advice-add 'org-read-date :around #'org-journal--org-read-date)
 
 ;; Journal mode definition
 ;;;###autoload
@@ -1330,14 +1342,15 @@ from oldest to newest."
 (defun org-journal-mark-entries ()
   "Mark days in the calendar for which a journal entry is present."
   (interactive)
-  (when (file-exists-p org-journal-dir)
-    (let ((current-time (current-time)))
-      (dolist (journal-entry (org-journal--list-dates))
-        (if (calendar-date-is-visible-p journal-entry)
-            (if (time-less-p (org-journal--calendar-date->time journal-entry)
-                             current-time)
-                (calendar-mark-visible-date journal-entry 'org-journal-calendar-entry-face)
-              (calendar-mark-visible-date journal-entry 'org-journal-calendar-scheduled-face)))))))
+  (unless org-journal-dont-mark-entries
+    (when (file-exists-p org-journal-dir)
+      (let ((current-time (current-time)))
+        (dolist (journal-entry (org-journal--list-dates))
+          (if (calendar-date-is-visible-p journal-entry)
+              (if (time-less-p (org-journal--calendar-date->time journal-entry)
+                               current-time)
+                  (calendar-mark-visible-date journal-entry 'org-journal-calendar-entry-face)
+                (calendar-mark-visible-date journal-entry 'org-journal-calendar-scheduled-face))))))))
 
 ;;;###autoload
 (defun org-journal-read-entry (_arg &optional event)

--- a/org-journal.el
+++ b/org-journal.el
@@ -403,7 +403,8 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
 
 (defvar org-journal--search-buffer "*Org-journal search*")
 
-(defvar org-journal-dont-mark-entries nil)
+(defvar org-journal-allow-mark-entries t
+  "Allows us to prevent marking entries in cases such as org-deadline and org-time-stamp")
 
 ;;;###autoload
 (add-hook 'calendar-today-visible-hook 'org-journal-mark-entries)
@@ -413,10 +414,10 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
 (defun org-journal--org-read-date (orig-fun &rest args)
   "In the case where the calendar is opened to input a timestamp, don't mark entries."
   (progn
-    (setq org-journal-dont-mark-entries t)
+    (setq org-journal-allow-mark-entries nil)
     (unwind-protect
         (apply orig-fun args)
-      (setq org-journal-dont-mark-entries nil))))
+      (setq org-journal-allow-mark-entries t))))
 
 ;;;###autoload
 (advice-add 'org-read-date :around #'org-journal--org-read-date)
@@ -1342,7 +1343,7 @@ from oldest to newest."
 (defun org-journal-mark-entries ()
   "Mark days in the calendar for which a journal entry is present."
   (interactive)
-  (unless org-journal-dont-mark-entries
+  (unless org-journal-allow-mark-entries
     (when (file-exists-p org-journal-dir)
       (let ((current-time (current-time)))
         (dolist (journal-entry (org-journal--list-dates))

--- a/org-journal.el
+++ b/org-journal.el
@@ -1343,15 +1343,15 @@ from oldest to newest."
 (defun org-journal-mark-entries ()
   "Mark days in the calendar for which a journal entry is present."
   (interactive)
-  (unless org-journal-allow-mark-entries
-    (when (file-exists-p org-journal-dir)
-      (let ((current-time (current-time)))
-        (dolist (journal-entry (org-journal--list-dates))
-          (if (calendar-date-is-visible-p journal-entry)
-              (if (time-less-p (org-journal--calendar-date->time journal-entry)
-                               current-time)
-                  (calendar-mark-visible-date journal-entry 'org-journal-calendar-entry-face)
-                (calendar-mark-visible-date journal-entry 'org-journal-calendar-scheduled-face))))))))
+  (if org-journal-allow-mark-entries
+      (when (file-exists-p org-journal-dir)
+        (let ((current-time (current-time)))
+          (dolist (journal-entry (org-journal--list-dates))
+            (if (calendar-date-is-visible-p journal-entry)
+                (if (time-less-p (org-journal--calendar-date->time journal-entry)
+                                 current-time)
+                    (calendar-mark-visible-date journal-entry 'org-journal-calendar-entry-face)
+                  (calendar-mark-visible-date journal-entry 'org-journal-calendar-scheduled-face))))))))
 
 ;;;###autoload
 (defun org-journal-read-entry (_arg &optional event)


### PR DESCRIPTION
(ugh. renaming the branch reset the PR. never again...)

I flipped the logic so it might be clearer now.

We always mark entries, unless we call org-read-date.

```
(defun org-journal--org-read-date (orig-fun &rest args)
  "In the case where the calendar is opened to input a timestamp, don't mark entries."
  (progn
    (setq org-journal-allow-mark-entries nil) <----- turn it off temporarily
    (unwind-protect
        (apply orig-fun args)               <------- (calendar) gets called in here, and therefore org-journal-mark-entries
      (setq org-journal-allow-mark-entries t)))) <---- turn it back on
```