### PR TITLE
Add feature to turn off scheduled entries having a timestamp.

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -244,6 +244,13 @@ When the current time is before the hour set by `org-extend-today-until'."
 By default, this is an org-mode sub-heading."
   :type 'string)
 
+(defcustom org-journal-schedule-include-time t
+  "Allows switching off the automatic adding of a timestamp for journal entries.
+
+By default, all scheduled journal entries will have a date and time. If you
+don't need the time by default, you can set this to nil to avoid that."
+  :type 'boolean)
+
 (defcustom org-journal-hide-entries-p t
   "If true all but the current entry will be hidden when creating a new one."
   :type 'boolean)
@@ -1106,7 +1113,7 @@ With non-nil prefix argument create a regular entry instead of a TODO entry."
       (insert "TODO "))
     (save-excursion
       (insert "\n")
-      (org-insert-time-stamp time t))))
+      (org-insert-time-stamp time org-journal-schedule-include-time))))
 
 ;;;###autoload
 (defun org-journal-reschedule-scheduled-entry (&optional time)


### PR DESCRIPTION
As per #389, I am adding a PR that adds this feature. First time working with this, and I am also on the move, so not quite sure everything is correct. But it _looks_ simple enough, hoping that it actually is.

Otherwise, please feel free to critique in any way, I should have a bit more time next week (but my schedule said I need to do this today, so I complied! ;))