### PR TITLE
don't break journaling if CREATED exists at file level #383

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -1061,6 +1061,14 @@ This is the counterpart of `org-journal--file-name->calendar-date' for
           (string-to-number (match-string 3 date))    ;; Day
           (string-to-number (match-string 1 date))))) ;; Year
 
+(defun org-journal--skip-meta-data ()
+  "Advance point past any file-level properties drawer.
+
+Extracted from org-roam (org-roam-end-of-meta-data)."
+  (when (looking-at org-property-drawer-re)
+    (goto-char (match-end 0))
+    (forward-line)))
+
 (defun org-journal--file->calendar-dates (file)
   "Return journal dates from FILE."
   (org-journal--with-journal
@@ -1068,6 +1076,7 @@ This is the counterpart of `org-journal--file-name->calendar-date' for
     (let (dates)
       (save-excursion
         (goto-char (point-min))
+        (org-journal--skip-meta-data)
         (while (re-search-forward org-journal--created-re nil t)
           (when (= (save-excursion (org-back-to-heading) (org-outline-level)) 1)
             (push (org-journal--entry-date->calendar-date) dates)))


### PR DESCRIPTION
The existence of a CREATED entry in the file-level property drawer causes =org-journal-new-entry= to fail. Ignore all file-level properties when searching through the file for the correct timestamp to start a new entry.

(resubmit for PR388)