### PR TITLE
Support a symlink directory as org-journal-dir

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -482,7 +482,7 @@ before it will be deposed."
 (defun org-journal-is-journal ()
   "Determine if file is a journal file."
   (and (buffer-file-name)
-       (string-match (org-journal--dir-and-file-format->pattern) (buffer-file-name))))
+       (string-match (org-journal--dir-and-file-format->pattern) (file-truename (buffer-file-name)))))
 
 ;; Open files in `org-journal-mode' if `org-journal-is-journal' returns true.
 (add-to-list 'magic-mode-alist '(org-journal-is-journal . org-journal-mode))


### PR DESCRIPTION
I found `org-journal-is-journal` fails to check the pattern of journal files in the symlink directory. I'm adding this PR to support a symlink directory as `org-journal-dir`.

In my understanding, `org-journal--dir-and-file-format->pattern` returns the pattern by chasing the symlink since it's implemented using `file-truename` but `buffer-file-name` returns a file symlink path.