### PR TITLE
go to the first heading before attempt to go up

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -1376,6 +1376,7 @@ from oldest to newest."
   (org-journal--decrypt)
   (if (org-journal--is-date-prefix-org-heading-p)
       (progn
+        (outline-next-heading)
         (org-up-heading-safe)
         (org-back-to-heading)
         (outline-hide-other)


### PR DESCRIPTION
when there's file header, carry over doesn't work, 
this fixes it.