### PR TITLE
Fix bug that hid previous date entries.

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -1381,7 +1381,7 @@ from oldest to newest."
       (progn
         (org-up-heading-safe)
         (org-back-to-heading)
-        (outline-hide-other)
+        (if org-journal-hide-entries-p (outline-hide-other))
         (outline-show-subtree))
     (outline-show-all)))
 


### PR DESCRIPTION
This commit resolves a bug that occurred in the "monthly" journal file setup. When in a file containing previous date's entries, running 'org-journal-new-entry would hide any entry not in the current date, regardless of the value of 'org-journal-hide-entries-p.