### PR TITLE
Improvements to org-journal-new-scheduled-entry and org-journal-reschedule-scheduled-entry

### DIFF
--- a/tests/org-journal-test.el
+++ b/tests/org-journal-test.el
@@ -53,7 +53,7 @@
   (org-journal-invalidate-cache))
 
 (defmacro org-journal-test-macro (&rest body)
-  "Wrapp a `org-journal' -- `ert'-test with default values."
+  "Wrap a `org-journal' -- `ert'-test with default values."
   (declare (indent 1))
   `(let* ((org-journal-dir (concat org-journal-dir-test "-link"))
           (comment-start-skip "^\\s-*#\\(?: \\|$\\)")
@@ -61,7 +61,7 @@
           (org-journal-file-type 'daily)
           (org-journal-date-format "Test header")
           (org-agenda-inhibit-startup t)
-          (org-journal-time-format "%R")
+          (org-journal-time-format "%R ")
           (org-journal-created-property-timestamp-format "%Y%m%d")
           org-journal-file-header
           org-journal-encrypt-journal


### PR DESCRIPTION
This commit improves the behavior of `org-journal-new-scheduled-entry` and `org-journal-reschedule-scheduled-entry`.
More specifically,
- It behaves more like `org-schedule` (with "SCHEDULED: ").
- Inserting a time stamp `<...>` is now more consistent. (no meaningless `00:00`, time range can also be specified.)
- The time stamp (not the current time) is also added to a heading (in an org-mode way: `TODO` + time, not time + `TODO`).


### Related issues/pull requests:

- https://github.com/bastibe/org-journal/issues/308 .
- https://github.com/bastibe/org-journal/issues/389 (and https://github.com/bastibe/org-journal/pull/390 (closed)).
- https://github.com/bastibe/org-journal/pull/338
- https://github.com/bastibe/org-journal/issues/48 (closed)


### Description:

- `org-journal-new-scheduled-entry` will insert followings if a time is not specified.

  `M-x org-journal-new-scheduled-entry`
  `+1[RET]` or `S-<right>[RET]`

  ```
  ** TODO _
  SCHEDULED: <2023-11-04 Sa>
  ```

  (`_` shows a cursor position)

- If you specify a time, `org-journal-new-scheduled-entry` inserts time in a heading **and** as a timestamp with "SCHEDULED: ".

  `M-x org-journal-new-scheduled-entry`
  `23:59[RET]`

  ```
  ** TODO 23:59 _			; Note that this is NOT the current time, but the scheduled time.
  SCHEDULED: <2023-11-03 Fr 23:59>
  ```

  You may think that the time stamp after "TODO" is unneeded/redandant, but it is useful when you use `org-todo-list` (`C-c a t`):

  ```
  20231104:   TODO 23:59 I must do this.
  ```

- You can also specify time range.

  `M-x org-journal-new-scheduled-entry`
  `22:00+1[RET]`

  ```
  ** TODO 22:00 _
  SCHEDULED: <2023-11-04 Sa 22:00-23:00>
  ```

- Use `C-u` to avoid inserting "TODO".

  `C-u M-x org-journal-new-scheduled-entry`
  `23:59[RET]`
  ```
  ** 23:59 _
  SCHEDULED: <2023-11-04 Sa 23:59>
  ```

Note that `org-journal-reschedule-scheduled-entry` now only changes a timestamp with "SCHEDULED: " (and the time in a heading). Bare timestamp `<...>` without "SCHEDULED: " remains untouched.
