### PR TITLE
Account for org-extend-today-until in org-journal-open-current-file

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -1267,7 +1267,8 @@ If NO-SELECT is non-nil, open it, but don't show it."
   "Open the current journal file"
   (interactive)
   (let ((org-journal-file (org-journal--get-entry-path
-                           (time-since (* 3600 org-extend-today-until)))))
+                           (time-subtract (current-time)
+                                          (* 3600 org-extend-today-until)))))
     (if (file-exists-p org-journal-file)
         (progn
           (funcall org-journal-find-file org-journal-file)

--- a/org-journal.el
+++ b/org-journal.el
@@ -1266,7 +1266,8 @@ If NO-SELECT is non-nil, open it, but don't show it."
 (defun org-journal-open-current-journal-file ()
   "Open the current journal file"
   (interactive)
-  (let ((org-journal-file (org-journal--get-entry-path)))
+  (let ((org-journal-file (org-journal--get-entry-path
+                           (time-since (* 3600 org-extend-today-until)))))
     (if (file-exists-p org-journal-file)
         (progn
           (funcall org-journal-find-file org-journal-file)


### PR DESCRIPTION
This makes `org-journal-open-current-file` respect `org-extend-today-until`. The variable is used the same way as in `org-today`.

Yes, I had to invoke that function at 3 AM on Monday to discover that bug.