### PR TITLE
Add support for age encryption via age.el

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -736,34 +736,34 @@ This allows the use of `org-journal-tag-alist' and
     (unless (if (org-journal--daily-p)
                 (or (search-forward entry-header nil t) (and (goto-char (point-max)) nil))
               (cl-loop
-                with date = (decode-time time)
-                with file-dates = (sort (org-journal--file->calendar-dates (buffer-file-name))
-                                        (lambda (a b)
-                                          (org-journal--calendar-date-compare b a)))
-                with entry
-                initially (setq date (list (nth 4 date) (nth 3 date) (nth 5 date)))
-                unless file-dates ;; New entry at bof
-                do
-                  (unless (re-search-forward (concat "^\\(" org-outline-regexp "\\)") nil t)
-                    (goto-char (point-max)))
-                  (if (org-at-heading-p)
-                      (progn
-                        (beginning-of-line)
-                        (insert "\n")
-                        (forward-line -1))
-                    (forward-line -1)
-                    (end-of-line))
-                and return nil
-                while file-dates
-                do
-                  (setq entry (car file-dates)
-                        file-dates (cdr file-dates))
-                if (or (org-journal--calendar-date-compare entry date) (equal entry date))
-                do
-                  (org-journal--search-forward-created entry)
-                  (when (org-journal--calendar-date-compare entry date) ;; New entry at eof, or somewhere in-between
-                    (org-end-of-subtree))
-                and return (equal entry date))) ;; If an entry exists don't create a header
+                    with date = (decode-time time)
+                    with file-dates = (sort (org-journal--file->calendar-dates (buffer-file-name))
+                                            (lambda (a b)
+                                              (org-journal--calendar-date-compare b a)))
+                    with entry
+                    initially (setq date (list (nth 4 date) (nth 3 date) (nth 5 date)))
+                    unless file-dates ;; New entry at bof
+                    do
+                    (unless (re-search-forward (concat "^\\(" org-outline-regexp "\\)") nil t)
+                      (goto-char (point-max)))
+                    (if (org-at-heading-p)
+                        (progn
+                          (beginning-of-line)
+                          (insert "\n")
+                          (forward-line -1))
+                      (forward-line -1)
+                      (end-of-line))
+                    and return nil
+                    while file-dates
+                    do
+                    (setq entry (car file-dates)
+                          file-dates (cdr file-dates))
+                    if (or (org-journal--calendar-date-compare entry date) (equal entry date))
+                    do
+                    (org-journal--search-forward-created entry)
+                    (when (org-journal--calendar-date-compare entry date) ;; New entry at eof, or somewhere in-between
+                      (org-end-of-subtree))
+                    and return (equal entry date))) ;; If an entry exists don't create a header
 
 
       (when (looking-back "[^\t ]" (point-at-bol))

--- a/org-journal.el
+++ b/org-journal.el
@@ -99,6 +99,8 @@
 (require 'org-crypt)
 (require 'seq)
 (require 'subr-x)
+(if (package-installed-p 'age)
+    (require 'age))
 
 ;; Silent byte-compiler
 (defvar view-exit-action)
@@ -245,10 +247,26 @@ passphrase to encrypt/decrypt it."
   :type 'boolean)
 
 (defcustom org-journal-encrypt-journal nil
-  "If non-nil, encrypt journal files using gpg.
+  "If non-nil, encrypt journal files.
+org-journal doesn't do the encryption itself,
+so you must have set up a transparent way of
+decryption and encryption.
+By default this is done using epa (EasyPG),
+which will automatically
 
-The journal files will have the file extension \".gpg\"."
+By default the journal files will have the file extension \".gpg\".
+You can change the file extension and therefore the encryption used via
+the `org-journal-encryption-format' variable."
   :type 'boolean)
+
+(defcustom org-journal-encryption-extension "gpg"
+  "The type of encryption to be used by apending the extension to
+the journal file name.
+Encryption is only used when `org-journal-encrypt-journal' is set.
+
+Currently supported extensions are \".gpg\" via EasyPG (epa) and
+\".age\" via age.el."
+  :type 'string)
 
 (define-obsolete-variable-alias  'org-journal-encrypt-on 'org-journal-encrypt-on-hook-fn "2.3.0")
 (defcustom org-journal-encrypt-on-hook-fn 'before-save-hook
@@ -535,7 +553,7 @@ before it will be deposed."
   "Return the current journal file pattern"
   (concat (file-name-as-directory (file-truename org-journal-dir))
           (org-journal--format->regex org-journal-file-format)
-          "\\(\\.gpg\\)?\\'"))
+          "\\(\.\\(gpg\\|age\\)\\)?\\'"))
 
 (defun org-journal--format->regex (format)
   (cl-loop
@@ -640,7 +658,7 @@ If no TIME is given, uses the current time."
                                     (org-journal--convert-time-to-file-type-time time))
                 org-journal-dir))))
     (when (and org-journal-encrypt-journal (not (file-exists-p file)))
-      (setq file (concat file ".gpg")))
+      (setq file (concat file "." org-journal-encryption-extension)))
     file))
 
 (defun org-journal--create-journal-dir ()
@@ -1291,7 +1309,7 @@ If NO-SELECT is non-nil, open it, but don't show it."
         (predicate (lambda (file-path)
                      (and (string-match-p (org-journal--dir-and-file-format->pattern) file-path)
                           (or org-journal-encrypt-journal
-                              (not (string-match-p "\.gpg$" file-path)))))))
+                              (not (string-match-p "\.\\(gpg\\|age\\)$" file-path)))))))
     (seq-filter predicate file-list)))
 
 
@@ -1922,9 +1940,17 @@ If STR is empty, search for all entries using `org-journal-time-prefix'."
 
 (defun org-journal-re-encrypt-journals (recipient)
   "Re-encrypt journal files."
-  (interactive (list (epa-select-keys (epg-make-context epa-protocol)
-                                      "Select new recipient for encryption.
-Only one recipient is supported.  ")))
+  (interactive (list (cond
+                       ((string= org-journal-encryption-extension "gpg")
+                        (epa-select-keys (epg-make-context epa-protocol)
+                                         "Select new recipient for encryption.
+Only one recipient is supported.  "))
+                       ((string= org-journal-encryption-extension "age")
+                            (age-select-keys (age-make-context 'Age age-armor)
+                                             "Select new recipients for encryption."))
+                       (t
+                        (error "Encryption extension \"%s\" is unsupported"
+                               org-journal-encryption-extension)))))
 
   (unless recipient
     (user-error "You need to specify exactly one recipient"))
@@ -1933,29 +1959,36 @@ Only one recipient is supported.  ")))
     (user-error "org-journal encryption not enabled"))
 
   (cl-loop
-   with buf
-   with kill-buffer
-   for journal in (org-journal--list-files)
-   do
-   (setq buf (find-buffer-visiting journal)
-         kill-buffer nil)
+        with buf
+        with kill-buffer
+        for journal-file-path in (org-journal--list-files)
+        if (string-match-p (format "\.%s$" org-journal-encryption-extension) journal-file-path)
+        do
+        (setq buf (find-buffer-visiting journal-file-path)
+              kill-buffer nil)
 
-   (when (and buf
-              (buffer-modified-p buf)
-              (y-or-n-p (format "Journal \"%s\" modified, save before re-encryption?"
-                                (file-name-nondirectory journal))))
-     (save-buffer buf))
+        (when (and buf
+                   (buffer-modified-p buf)
+                   (y-or-n-p (format "Journal \"%s\" modified, save before re-encryption?"
+                                     (file-name-nondirectory journal-file-path))))
+          (save-buffer buf))
 
-   (unless buf
-     (setq kill-buffer t
-           buf (find-file-noselect journal)))
+        (unless buf
+          (setq kill-buffer t
+                buf (find-file-noselect journal-file-path)))
 
-   (with-current-buffer buf
-     (let ((epa-file-encrypt-to (epg-sub-key-id (car (epg-key-sub-key-list (car recipient))))))
-       (set-buffer-modified-p t)
-       (save-buffer)
-       (when kill-buffer
-         (kill-buffer))))))
+        (with-current-buffer buf
+          (let ((epa-file-encrypt-to
+                 age-file-encrypt-to))
+            (cond
+              ((string= org-journal-encryption-extension "gpg")
+               (setq-local epa-file-encrypt-to (epg-sub-key-id (car (epg-key-sub-key-list (car recipient))))))
+              ((string= org-journal-encryption-extension "age")
+               (setq-local age-file-encrypt-to recipient)))
+            (set-buffer-modified-p t)
+            (save-buffer)
+            (when kill-buffer
+              (kill-buffer))))))
 
 (defun org-journal--decrypt ()
   "Decrypt journal entry at point."

--- a/org-journal.el
+++ b/org-journal.el
@@ -99,8 +99,6 @@
 (require 'org-crypt)
 (require 'seq)
 (require 'subr-x)
-(if (package-installed-p 'age)
-    (require 'age))
 
 ;; Silent byte-compiler
 (defvar view-exit-action)
@@ -1946,8 +1944,9 @@ If STR is empty, search for all entries using `org-journal-time-prefix'."
                                          "Select new recipient for encryption.
 Only one recipient is supported.  "))
                        ((string= org-journal-encryption-extension "age")
-                            (age-select-keys (age-make-context 'Age age-armor)
-                                             "Select new recipients for encryption."))
+                        (require 'age)
+                        (age-select-keys (age-make-context 'Age age-armor)
+                                         "Select new recipients for encryption."))
                        (t
                         (error "Encryption extension \"%s\" is unsupported"
                                org-journal-encryption-extension)))))

--- a/org-journal.el
+++ b/org-journal.el
@@ -1977,8 +1977,8 @@ Only one recipient is supported.  "))
                 buf (find-file-noselect journal-file-path)))
 
         (with-current-buffer buf
-          (let ((epa-file-encrypt-to
-                 age-file-encrypt-to))
+          (let ((epa-file-encrypt-to)
+                (age-file-encrypt-to))
             (cond
               ((string= org-journal-encryption-extension "gpg")
                (setq-local epa-file-encrypt-to (epg-sub-key-id (car (epg-key-sub-key-list (car recipient))))))


### PR DESCRIPTION
- require age.el if the package is installed https://github.com/anticomputer/age.el
- add new customizable variable `org-journal-encryption-extension` to control the file extension appended to the file name to trigger transparent encryption
- recognize `.age` files as journal files
- generate encrypted files based on chosen file extension instead of hard coding `.gpg`
- support `.age` files in `org-journal-re-encrypt-journals` - only re-encrypt files for the currently chosen encryption extension - functional change: don't edit/re-save files that aren't encrypted. I assume that they where handled by this function in the past was an oversight and not intended. - allow multiple recipients for `age` encryption

closes #441

---

age encyrption works with this change.
TODOs from age encrypted journal files get added to the agenda. (`org-journal-enable-agenda-integration`)

I wasn't sure how to do optional dependencies for Emacs packages.
If someone tries to set `age` as extension the `org-journal-re-encrypt-journals`
function will fail because of missing functions, of course.

`org-journal-re-encrypt-journals` works for me if `age-default-recipient` and `age-default-identity` are set,
but things got a bit weird when I hadn't set those.
I might be missing some settings, but at some point age encryption wasn't working at all and I had to restart Emacs.

Theoretically org-journal would work with any encryption that implements transparent, as long as the `org-journal--list-files` and `org-journal--dir-and-file-format->pattern` would get consider the value of `org-journal-encryption-extension` in their regexes. If we don't want to implement this then it's probably better to make `org-journal-encryption-extension` of `:type '(choice (const :tag "age" age) (const :tag "gpg" gpg))` instead of `'string`.


### Instructions for testing

- Get `age` binaries: https://github.com/FiloSottile/age/releases/latest
- Place binaries in $PATH

Create age keys:

```bash
age-keygen -o key.txt
age-keygen -y key.txt > key.pub
```

Example `age.el` configuration for testing:

```elisp
(use-package age
  :ensure t
  :demand t
  :custom
  (age-program "age")
  (age-default-identity "~/.age/key.txt")
  (age-default-recipient '("~/.age/key.pub"))
  :config
  (age-file-enable))
```

Activate `age` encrption for `org-journal`:

```elisp
(setq 
  org-journal-encrypt-journal t
  org-journal-encryption-extension "age")
```
