### PR TITLE
carryover-items utilized org-up-heading-safe which moves up before first heading 

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -941,7 +941,9 @@ to process the carryover entries in `prev-buffer'."
     (save-excursion
       (if (org-journal--daily-p)
           (goto-char (point-min))
-        (while (org-up-heading-safe)))
+        (progn (while (org-up-heading-safe))
+               (if (org-before-first-heading-p)
+                   (outline-next-heading))))
 
       (unless (null org-journal-skip-carryover-drawers)
         (org-journal--remove-drawer))
@@ -958,7 +960,9 @@ to process the carryover entries in `prev-buffer'."
                                     (if (org-journal--daily-p)
                                         (org-journal--file-name->calendar-date (buffer-file-name))
                                       (save-excursion
-                                        (while (org-up-heading-safe))
+                                        (progn (while (org-up-heading-safe))
+                                               (if (org-before-first-heading-p)
+                                                 (outline-next-heading)))
                                         (org-journal--entry-date->calendar-date))))))
              nil nil nil 1)))))
 


### PR DESCRIPTION

though the final call returns nil, the point still move up

So it will move up before first heading, which cause issue when there is a property drawer before first heading.

I use both denote and org-journal and wish to combine them together (to be able to access each other), denote added CUSTOM_ID property at the file level, which cause issue when moved before first heading and checking CREATED property in "org-journal--entry-date->calendar-date"