### PR TITLE
Allow any alpha character in date format

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -438,7 +438,7 @@ This runs once per date, before `org-journal-after-entry-create-hook'.")
 buffer not open already, otherwise `nil'.")
 
 (defvar org-journal--format-rx-alist
-  '(("%[aAbB]" . "\\\\(?4:[a-zA-Z]\\\\{3,\\\\}\\\\)")
+  '(("%[aAbB]" . "\\\\(?4:[[:alpha:]]\\\\{3,\\\\}\\\\)")
     ("%d" . "\\\\(?3:[0-9]\\\\{2\\\\}\\\\)")
     ("%m" . "\\\\(?2:[0-9]\\\\{2\\\\}\\\\)")
     ("%Y" . "\\\\(?1:[0-9]\\\\{4\\\\}\\\\)")


### PR DESCRIPTION
Some locales have day names with accents, such as Esperanto.  When using org-journal in such a locale and customizing `org-journal-created-property-timestamp-format` to support org inactive timestamps, as `[%Y-%m-%d %a]` org-journal will fail with an error on many operations:

    org-journal--entry-date->calendar-date: Created property timestamp format "[%Y-%m-%d %a]" doesn’t match CREATED property value ([2021-12-02 ĵaŭ]) from entry at line: Line 29

This is because the `%a` format specifier in org-journal only accepts unaccented day names.  This patch allows `%a` to accept any character Emacs classifies as alpha.