### PR TITLE
don't try to create new day on partial line #354

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -769,7 +769,7 @@ This allows the use of `org-journal-tag-alist' and
                     and return (equal entry date))) ;; If an entry exists don't create a header
 
 
-      (when (looking-back "[^\t ]" (line-beginning-position))
+      (unless (bolp)
         (insert "\n"))
       (insert entry-header)
 


### PR DESCRIPTION
When creating a new day's entry header (in weekly/monthly/yearly mode), ensure that the new header will begin on a new line. The easy way to do that is to go to the end of the file (where the header should be created) and see if that point is also at the beginning of a line: if it isn't insert a line break and then it _will_ be at the beginning of a line.

(The previous method would also remove up to 2 blank lines at the end of the file before inserting the new entry header, but I think that was a side effect, not intended behavior. If a user wants excess blank lines removed, a post-save hook is probably a better option, anyway.)