### PR TITLE
Option to hide titles of previous days' entries when creating a new entry #439

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -239,8 +239,14 @@ By default, this is an org-mode sub-heading."
   :type 'string)
 
 (defcustom org-journal-hide-entries-p t
-  "If true all but the current entry will be hidden when creating a new one."
-  :type 'boolean)
+  "Controls what information in the current journal file is shown or hidden when a new entry is created:
+   - If nil, the full text of all entries will be displayed.
+   - If 'previous and journal type is not daily, previous dates will be shown but not the titles of their individual journal entries; the titles of journal entries for the current date will be shown but not their text.
+   - Any other value will show the titles of all journal entries but not their text.
+   In previous versions, this was a boolean so the default value was t.
+
+  'previous is probably only helpful if you have many journal entries in each day or want to hide the headings of entries from previous days."
+  :type 'string)
 
 (defcustom org-journal-enable-encryption nil
   "Add `org-crypt-tag-matcher' tag for encrypted entries when non-nil.
@@ -861,7 +867,19 @@ hook is run."
       (org-journal--insert-entry time org-extend-today-until-active-p no-timestamp))
 
     (if (and org-journal-hide-entries-p (org-journal--time-entry-level))
-        (outline-hide-sublevels (org-journal--time-entry-level))
+        ;; When hide-entries is set to 'previous AND this is a
+        ;; weekly/monthly/yearly journal, collapse all the previous
+        ;; days to hide their individual journal entries, and show
+        ;; only individual entries (without their text) from today.
+        ;; Otherwise, as long as hide-entries is not nil, list all
+        ;; the previous entries (without their text).
+        (if (and (string= org-journal-hide-entries-p 'previous)
+                 (not (org-journal--daily-p)))
+            (progn
+              (outline-hide-sublevels (max 1 (- (org-journal--time-entry-level) 1)))
+              (outline-show-children (org-journal--time-entry-level)))
+          (outline-hide-sublevels (org-journal--time-entry-level)))
+      ;; Since hide-entries is nil, show the full text of all entries.
       (save-excursion (org-journal--finalize-view)))
 
     (when should-add-entry-p


### PR DESCRIPTION
Enhancement for #439: changes `org-journal-hide-entries-p` to allow a new value, `'previous` which provides the requested behavior: hiding all journal entries in previous days.